### PR TITLE
Add error handling for auth errors

### DIFF
--- a/sp_api/auth/access_token_client.py
+++ b/sp_api/auth/access_token_client.py
@@ -28,7 +28,7 @@ class AccessTokenClient(BaseClient):
     def _request(self, url, data, headers):
         response = requests.post(url, data=data, headers=headers)
         response_data = response.json()
-        if response.status_code != '200':
+        if response.status_code != 200:
             error_message = response_data.get('error_description')
             error_code = response_data.get('error')
             raise AuthorizationError(error_code, error_message, response.status_code)

--- a/sp_api/auth/access_token_client.py
+++ b/sp_api/auth/access_token_client.py
@@ -1,12 +1,14 @@
 import requests
 
+import hashlib
 import logging
 from cachetools import TTLCache
 
+from sp_api.base import BaseClient
+
 from .credentials import Credentials
 from .access_token_response import AccessTokenResponse
-from sp_api.base import BaseClient
-import hashlib
+from .exceptions import AuthorizationError
 
 cache = TTLCache(maxsize=10, ttl=3600)
 grantless_cache = TTLCache(maxsize=10, ttl=3600)
@@ -23,6 +25,15 @@ class AccessTokenClient(BaseClient):
         super().__init__(account, credentials)
         self.cred = Credentials(refresh_token, self.credentials)
 
+    def _request(self, url, data, headers):
+        response = requests.post(url, data=data, headers=headers)
+        response_data = response.json()
+        if response.status_code != '200':
+            error_message = response_data.get('error_description')
+            error_code = response_data.get('error')
+            raise AuthorizationError(error_code, error_message, response.status_code)
+        return response_data
+
     def get_auth(self) -> AccessTokenResponse:
         """
         Get's the access token
@@ -35,12 +46,11 @@ class AccessTokenClient(BaseClient):
             access_token = cache[cache_key]
             logger.debug('from cache')
         except KeyError:
-            response = requests.post(self.scheme + self.host + self.path, data=self.data, headers=self.headers)
+            request_url = self.scheme + self.host + self.path
+            access_token = self._request(request_url, self.data, self.headers)
             logger.debug('token refreshed')
             cache = TTLCache(maxsize=10, ttl=3600)
-            cache[cache_key] = response.json()
-            access_token = response.json()
-
+            cache[cache_key] = access_token
         return AccessTokenResponse(**access_token)
 
     def get_grantless_auth(self):
@@ -60,11 +70,11 @@ class AccessTokenClient(BaseClient):
             access_token = grantless_cache[cache_key]
             logger.debug('from_cache')
         except KeyError:
-            response = requests.post(self.scheme + self.host + self.path, data=self.grantless_data, headers=self.headers)
+            request_url = self.scheme + self.host + self.path
+            access_token = self._request(request_url, data=self.grantless_data, headers=self.headers)
             logger.debug('token_refreshed')
             grantless_cache = TTLCache(maxsize=10, ttl=3600)
-            grantless_cache[cache_key] = response.json()
-            access_token = response.json()
+            grantless_cache[cache_key] = access_token
 
         return AccessTokenResponse(**access_token)
 

--- a/sp_api/auth/exceptions.py
+++ b/sp_api/auth/exceptions.py
@@ -1,0 +1,15 @@
+class AuthorizationError(Exception):
+    """
+    Authorization Error
+
+    Parameters:
+
+        error_code: str Error code from amazon auth api
+        error_msg: str Error sm
+        status_code: integer Response status code from amazon auth api
+    """
+
+    def __init__(self, error_code, error_msg, status_code):
+        self.error_code = error_code
+        self.message = error_msg
+        self.status_code = status_code

--- a/tests/api/fulfillment_inbound/test_fulfillment_inbound.py
+++ b/tests/api/fulfillment_inbound/test_fulfillment_inbound.py
@@ -1,0 +1,9 @@
+# from datetime import datetime, timedelta
+#
+# from sp_api.api import FulfillmentInbound
+#
+# def test_get_shipments():
+#     r = FulfillmentInbound().get_shipments(QueryType='DATE_RANGE', LastUpdatedAfter=(datetime.now() - timedelta(days=30)).isoformat(), LastUpdatedBefore=datetime.now().isoformat(), ShipmentStatusList=','.join([
+#         'WORKING','SHIPPED','RECEIVING','CANCELLED','DELETED','CLOSED','ERROR','IN_TRANSIT','DELIVERED','CHECKED_IN'
+#     ]))
+#     print(r)


### PR DESCRIPTION
In case amazon auth API is not successful then we need throw exception at right place.  Else it takes the error response as access token and later the SP API fails with UnAuthorisedError causing confusion about why token is not working when the error was in generating token itself.