### PR TITLE
fix: bad signature response with wrong canonical query string

### DIFF
--- a/sp_api/base/aws_sig_v4.py
+++ b/sp_api/base/aws_sig_v4.py
@@ -40,12 +40,11 @@ class AWSSigV4(AuthBase):
         host = p.hostname
         uri = urllib.parse.quote(p.path)
 
-        if len(p.query) > 0:
-            qs = dict(map(lambda i: i.split('='), p.query.split('&')))
-        else:
-            qs = dict()
+        # sort query parameters alphabetically
+        split_query_parameters = list(map(lambda param: param.split('='), p.query.split('&')))
+        ordered_query_parameters = sorted(split_query_parameters, key=lambda param: (param[0], param[1]))
+        canonical_querystring = "&".join(map(lambda param: "=".join(param), ordered_query_parameters))
 
-        canonical_querystring = "&".join(map(lambda x: '='.join(x), sorted(qs.items())))
         headers_to_sign = {'host': host, 'x-amz-date': self.amzdate}
         if self.aws_session_token is not None:
             headers_to_sign['x-amz-security-token'] = self.aws_session_token
@@ -85,4 +84,3 @@ class AWSSigV4(AuthBase):
             'x-amz-security-token': self.aws_session_token
         })
         return r
-

--- a/sp_api/base/aws_sig_v4.py
+++ b/sp_api/base/aws_sig_v4.py
@@ -41,8 +41,12 @@ class AWSSigV4(AuthBase):
         uri = urllib.parse.quote(p.path)
 
         # sort query parameters alphabetically
-        split_query_parameters = list(map(lambda param: param.split('='), p.query.split('&')))
-        ordered_query_parameters = sorted(split_query_parameters, key=lambda param: (param[0], param[1]))
+        if len(p.query) > 0:
+            split_query_parameters = list(map(lambda param: param.split('='), p.query.split('&')))
+            ordered_query_parameters = sorted(split_query_parameters, key=lambda param: (param[0], param[1]))
+        else:
+            ordered_query_parameters = list()
+
         canonical_querystring = "&".join(map(lambda param: "=".join(param), ordered_query_parameters))
 
         headers_to_sign = {'host': host, 'x-amz-date': self.amzdate}


### PR DESCRIPTION
Any endpoint that has a query parameter requiring data in lists seems to create malformed querystrings while signing the request.

For example, a request to fetch orders with the following parameters:

```json
{
    "CreatedAfter": "2021-04-16T05:49:18.307175",
    "MaxResultsPerPage": 30,
    "MarketplaceIds": [
        "ATVPDKIKX0DER"
    ],
    "OrderStatuses": [
        "Unshipped",
        "PartiallyShipped",
        "Shipped",
        "Canceled"
    ]
}
```

would expect the canonical querystring to unwrap each element in the `OrderStatuses` parameter while sorting them:

```
CreatedAfter=2021-04-16T05%3A49%3A18.307175&MarketplaceIds=ATVPDKIKX0DER&MaxResultsPerPage=30&OrderStatuses=Canceled&OrderStatuses=PartiallyShipped&OrderStatuses=Shipped&OrderStatuses=Unshipped
```

but since a dictionary was being used to manage the parameters, the querystring would instead become:

```
CreatedAfter=2021-04-16T05%3A49%3A18.307175&MarketplaceIds=ATVPDKIKX0DER&MaxResultsPerPage=30&OrderStatuses=Canceled
```

which in turn would create the wrong signature.

I've changed the process to use a list instead of a dict, so that information isn't lost.

Thanks for making this library!

<details>
<summary>Error Response</summary>

```json
{
  "errors": [
    {
      "code": "InvalidSignature",
      "message": "The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
          The Canonical String for this request should have been
          GET
          /orders/v0/orders
          CreatedAfter=2021-04-16T05%3A49%3A18.307175&MarketplaceIds=ATVPDKIKX0DER&MaxResultsPerPage=30&OrderStatuses=Canceled&OrderStatuses=PartiallyShipped&OrderStatuses=Shipped&OrderStatuses=Unshipped
          host:sellingpartnerapi-na.amazon.com
          x-amz-date:20210417T111936Z
          x-amz-security-token:<REDACTED>

          host;x-amz-date;x-amz-security-token
          <REDACTED>

          The String-to-Sign should have been
          AWS4-HMAC-SHA256
          20210417T111936Z
          20210417/us-east-1/execute-api/aws4_request
          <REDACTED>
        "
    }
  ]
}
```

</details>