### PR TITLE
fix `'Missing or invalid request parameters: [marketplaceIds]'`

### DIFF
--- a/sp_api/api/solicitations/solicitations.py
+++ b/sp_api/api/solicitations/solicitations.py
@@ -67,5 +67,5 @@ For more information, see "Usage Plans and Rate Limits" in the Selling Partner A
             ApiResponse:
         """
     
-        return self._request(fill_query_params(kwargs.pop('path'), amazonOrderId), data=kwargs)
+        return self._request(fill_query_params(kwargs.pop('path'), amazonOrderId), params=kwargs)
     


### PR DESCRIPTION
for solicitations API, the marketplace has to be passed as a URL parameter
* https://github.com/amzn/selling-partner-api-docs/blob/main/references/solicitations-api/solicitations.md#createproductreviewandsellerfeedbacksolicitation

```
Solicitations(credentials=credentials, marketplace=Marketplaces.US).create_product_review_and_seller_feedback_solicitation('113-xxx-xxx',marketplaceIds='ATVPDKIKX0DER')
```