### PR TITLE
Fixed put_listings_item

### DIFF
--- a/sp_api/api/listings_items/listings_items.py
+++ b/sp_api/api/listings_items/listings_items.py
@@ -86,8 +86,8 @@ The x-amzn-RateLimit-Limit response header returns the usage plan rate limits th
         return self._request(fill_query_params(kwargs.pop('path'), sellerId), data=kwargs)
     
 
-    @sp_endpoint('/listings/2020-09-01/items/{}', method='PUT')
-    def put_listings_item(self, sellerId, **kwargs) -> ApiResponse:
+    @sp_endpoint('/listings/2020-09-01/items/{}/{}', method='PUT')
+    def put_listings_item(self, sellerId, sku, **kwargs) -> ApiResponse:
         """
         put_listings_item(self, sellerId, **kwargs) -> ApiResponse
 
@@ -129,5 +129,5 @@ The x-amzn-RateLimit-Limit response header returns the usage plan rate limits th
             ApiResponse:
         """
     
-        return self._request(fill_query_params(kwargs.pop('path'), sellerId), data=kwargs)
+        return self._request(fill_query_params(kwargs.pop('path'), sellerId, sku), data=kwargs.get('body'), params=kwargs)
     

--- a/sp_api/base/client.py
+++ b/sp_api/base/client.py
@@ -96,7 +96,7 @@ class Client(BaseClient):
             self._add_marketplaces(data if self.method in ('POST', 'PUT') else params)
 
         res = request(self.method, self.endpoint + path, params=params,
-                      data=json.dumps(data) if data and self.method in ('POST', 'PUT') else None, headers=headers or self.headers,
+                      data=json.dumps(data) if data and self.method in ('POST', 'PUT', 'PATCH') else None, headers=headers or self.headers,
                       auth=self._sign_request())
 
         return self._check_response(res)


### PR DESCRIPTION
Same problem, endpoint need to 2 path params not only one:
<!DOCTYPE html>

Path | sellerId  required | A selling partner identifier, such as a merchant account or vendor code. | string
-- | -- | -- | --
Path | sku  required | A selling partner provided identifier for an Amazon listing. | string

The body param required need to be isolated from the **kwargs as data=kwargs.get('body')

<!DOCTYPE html>

Body | body  required | The request body schema for the putListingsItem operation.
-- | -- | --

The regular call could be:

# For reference only
seller_id = 'AXXXXXXXXXXXXX'
seller_sku = 'NEW-SKU-TR-7838383884'
issue_locale = 'es_ES'
marketplace_id = 'A1RKKUPIHCS9HS'


dictionary = {
    "productType": "LUGGAGE",
    "requirements": "LISTING",
    "attributes": {
        "recommended_browse_nodes": [
            {
                "value": "2008004031",
                "marketplace_id": "A1RKKUPIHCS9HS"
            }
        ],
        ...
    }
}

try:

    res = ListingsItems(account=store, marketplace=marketplace).put_listings_item(
        sellerId=seller_id,
        sku=seller_sku,
        marketplaceIds=marketplace_id_es,
        issueLocale=issue_locale,
        body=dictionary
    )

    logging.info(res)

except SellingApiException as ex:
    print(ex)
