### PR TITLE
Added endpoint /catalog/v0/categories

### DIFF
--- a/sp_api/api/catalog/catalog.py
+++ b/sp_api/api/catalog/catalog.py
@@ -68,3 +68,32 @@ class Catalog(Client):
         if 'Query' in kwargs:
             kwargs.update({'Query': urllib.parse.quote_plus(kwargs.pop('Query'))})
         return self._request(kwargs.pop('path'), params=kwargs)
+
+    @sp_endpoint('/catalog/v0/categories')
+    def list_categories(self, **kwargs) -> ApiResponse:
+        """
+        list_categories(self, **kwargs) -> ApiResponse
+        Returns the parent categories to which an item belongs, based on the specified ASIN or SellerSKU
+
+        **Usage Plan:**
+
+        ======================================  ==============
+        Rate (requests per second)               Burst
+        ======================================  ==============
+        1                                       40
+        ======================================  ==============
+
+
+        For more information, see "Usage Plans and Rate Limits" in the Selling Partner API documentation.
+
+        Args:
+            key MarketplaceId: str
+            key ASIN: str
+            key SellerSKU: str
+
+        Returns:
+            ListCatalogCategoriesResponse:
+        """
+        if 'Query' in kwargs:
+            kwargs.update({'Query': urllib.parse.quote_plus(kwargs.pop('Query'))})
+        return self._request(kwargs.pop('path'), params=kwargs)


### PR DESCRIPTION
Missing end point:

[https://github.com/amzn/selling-partner-api-docs/blob/main/references/catalog-items-api/catalogItemsV0.md](https://github.com/amzn/selling-partner-api-docs/blob/main/references/catalog-items-api/catalogItemsV0.md)

<h3>GET /catalog/v0/categories</h3><p></a>Description</h4><p>Returns the parent categories to which an item belongs, based on the specified ASIN or SellerSKU.</p><p>Usage Plans:</strong></p>

Plan type | Rate (requests per second) | Burst
-- | -- | --
Default | 1 | 40
Selling partner specific | Variable | Variable

<h4>Parameters</h4>

Type | Name | Description | Schema
-- | -- | -- | --
Query | MarketplaceId  required | A marketplace identifier. Specifies the marketplace for the item. | string
Query | ASIN  optional | The Amazon Standard Identification Number (ASIN) of the item. | string
Query | SellerSKU  optional | Used to identify items in the given marketplace. SellerSKU is qualified by the seller's SellerId, which is included with every operation that you submit. | string



