### PR TITLE
#193: Make get_authorization_code grantless, with migration scope.

### DIFF
--- a/sp_api/api/authorization/authorization.py
+++ b/sp_api/api/authorization/authorization.py
@@ -10,7 +10,7 @@ class Authorization(Client):
 
     The Selling Partner API for Authorization helps developers manage authorizations and check the specific permissions associated with a given authorization.
     """
-
+    grantless_scope = 'sellingpartnerapi::migration'
 
     @sp_endpoint('/authorization/v1/authorizationCode', method='GET')
     def get_authorization_code(self, **kwargs) -> ApiResponse:
@@ -40,5 +40,5 @@ For more information, see "Usage Plans and Rate Limits" in the Selling Partner A
             ApiResponse:
         """
     
-        return self._request(kwargs.pop('path'),  params=kwargs)
+        return self._request_grantless_operation(kwargs.pop('path'),  params=kwargs)
 

--- a/sp_api/api/notifications/notifications.py
+++ b/sp_api/api/notifications/notifications.py
@@ -6,6 +6,7 @@ class Notifications(Client):
     """
     :link: https://github.com/amzn/selling-partner-api-docs/blob/main/references/notifications-api/notifications.md
     """
+    grantless_scope = 'sellingpartnerapi::notifications'
 
     @deprecated
     def add_subscription(self, notification_type: NotificationType or str, **kwargs):

--- a/sp_api/base/client.py
+++ b/sp_api/base/client.py
@@ -20,6 +20,7 @@ role_cache = TTLCache(maxsize=10, ttl=3600)
 
 class Client(BaseClient):
     boto3_client = None
+    grantless_scope = ''
 
     def __init__(
             self,
@@ -64,7 +65,9 @@ class Client(BaseClient):
 
     @property
     def grantless_auth(self) -> AccessTokenResponse:
-        return self._auth.get_grantless_auth()
+        if not self.grantless_scope:
+            raise Exception("Grantless operations require scope")
+        return self._auth.get_grantless_auth(self.grantless_scope)
 
     @property
     def role(self):


### PR DESCRIPTION
Please review proposed solution for #193 and suggest changes, where necessary.

Notable changes:
  * AccessTokenClient.grantless_data is no longer a property, it's a method accepting scope_value parameter.
  * AccessTokenClient.get_grantless_auth() accepts scope parameter, with default value used by Notifications API - this is an attempt to remain compatible with code that was using `get_grantless_auth()` directly.
  *  AccessTokenClient.get_grantless_auth() doesn't recreate TTLCache object, but rather clears existing one - I'm unsure if this is even necessary each time KeyError happens. IMO we could just add new value to cache, without purging all other keys. But even if we want to purge, creating new object creates a risk that 3rd party module keeping reference to `grantless_cache` will still keep it, so we may end up having 2 instances of `grantless_cache`.