### PR TITLE
six dependency updated to version >=1.15,<2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version='0.6.2',
     install_requires=[
         "requests",
-        "six~=1.15.0",
+        "six>=1.15,<2",
         "boto3~=1.16.39",
         "cachetools~=4.2.0",
         "pycryptodome",


### PR DESCRIPTION
This pull request allows usage of python-amazon-sp-api with the most recent version of the six library at the moment and possibly in the future (until 2.0). 