### PR TITLE
added missing CustomerType optional param

### DIFF
--- a/sp_api/api/products/products.py
+++ b/sp_api/api/products/products.py
@@ -182,4 +182,6 @@ class Products(Client):
                                      'ItemType': item_type,
                                      **({'ItemCondition': kwargs.pop(
                                          'ItemCondition')} if 'ItemCondition' in kwargs else {}),
+                                     **({'CustomerType': kwargs.pop(
+                                         'CustomerType')} if 'CustomerType' in kwargs else {}),
                                      'MarketplaceId': kwargs.get('MarketplaceId', self.marketplace_id)})


### PR DESCRIPTION
Missing

Query | CustomerType  optional | Indicates whether to request pricing information from the point of view of Consumer or Business buyers. Default is Consumer. | enum (CustomerType)
-- | -- | -- | --

Query	[CustomerType](https://developer-docs.amazon.com/sp-api#customertype-subgroup-1) 
optional	Indicates whether to request pricing information from the point of view of Consumer or Business buyers. Default is Consumer.	enum (CustomerType)

Example:

```
    try:

        res = Products(account=store, marketplace=marketplace).get_competitive_pricing_for_skus(
            marketplaceIds=marketplace_id,
            seller_sku_list=sku_list,
            CustomerType='Business'
        )

        logging.info(res)
        result = res.payload
        # logging.info(result)

    except SellingApiException as ex:
        logging.info(ex)
```
