### PR TITLE
Change + to %20 in query params

### DIFF
--- a/sp_api/base/aws_sig_v4.py
+++ b/sp_api/base/aws_sig_v4.py
@@ -47,6 +47,7 @@ class AWSSigV4(AuthBase):
         else:
             ordered_query_parameters = list()
 
+        ordered_query_parameters = [[elm[0], elm[1].replace('+', '%20')] for elm in ordered_query_parameters] # hack to get around amazon bug
         canonical_querystring = "&".join(map(lambda param: "=".join(param), ordered_query_parameters))
 
         headers_to_sign = {'host': host, 'x-amz-date': self.amzdate}


### PR DESCRIPTION
Amazon has been giving me a signature error when I try to get prep instructions for a SellerSku which contains a space character. The error string saying what "should have" been signed has the space encoded as a %20, but the actual canonical_request has the space encoded as a plus.I think this is an Amazon bug and I shoudl be able to encode a space either way, so long as I am signing the actual string sent. Anyway replacing the + with %20 in the encoded query params allows the call to succeed.