### PR TITLE
Add proxies to request with Request

### DIFF
--- a/sp_api/base/client.py
+++ b/sp_api/base/client.py
@@ -33,7 +33,8 @@ class Client(BaseClient):
             refresh_token=None,
             account='default',
             credentials=None,
-            restricted_data_token=None
+            restricted_data_token=None,
+            proxies=None
     ):
         self.credentials = CredentialProvider(account, credentials).credentials
         session = boto3.session.Session()
@@ -47,6 +48,7 @@ class Client(BaseClient):
         self.region = marketplace.region
         self.restricted_data_token = restricted_data_token
         self._auth = AccessTokenClient(refresh_token=refresh_token, credentials=self.credentials)
+        self.proxies = proxies
 
     def _get_cache_key(self, token_flavor=''):
         return 'role_' + hashlib.md5(
@@ -122,7 +124,8 @@ class Client(BaseClient):
                       params=params,
                       data=json.dumps(data) if data and self.method in ('POST', 'PUT', 'PATCH') else None,
                       headers=headers or self.headers,
-                      auth=self._sign_request())
+                      auth=self._sign_request(),
+                      proxies=self.proxies)
         return self._check_response(res)
 
     def _check_response(self, res) -> ApiResponse:


### PR DESCRIPTION
Fixes #438 

This adds the possibility to use proxies when the request to SP-API is made.

The `proxies` parameter in `Client` is expected to be the same as in the `Request` library.
Example taken from the `Request` doc: https://docs.python-requests.org/en/master/user/advanced/#proxies
```
proxies = {
  'http': 'http://10.10.1.10:3128',
  'https': 'http://10.10.1.10:1080',
}

Finances(proxies=proxies).get_financial_events_for_order(order_id="123456789")
```