### PR TITLE
Force user SKU quote

### DIFF
--- a/sp_api/api/product_fees/product_fees.py
+++ b/sp_api/api/product_fees/product_fees.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote_plus
+
 from sp_api.base.helpers import sp_endpoint, fill_query_params
 from sp_api.base import Client, ApiResponse
 
@@ -10,7 +12,7 @@ class ProductFees(Client):
     @sp_endpoint('/products/fees/v0/listings/{}/feesEstimate', method='POST')
     def get_product_fees_estimate_for_sku(self, seller_sku, price: float, shipping_price=None, currency='USD',
                                           is_fba=False, points: dict = None, marketplace_id: str = None,
-                                          optional_fulfillment_program: str = None,
+                                          optional_fulfillment_program: str = None, force_safe_sku: bool = True,
                                           **kwargs) -> ApiResponse:
         """
         get_product_fees_estimate_for_sku(self, seller_sku, price: float, shipping_price=None, currency='USD', is_fba=False, points: dict = dict, **kwargs) -> ApiResponse
@@ -38,12 +40,18 @@ class ProductFees(Client):
             points:
             marketplace_id: str | Defaults to self.marketplace_id
             optional_fulfillment_program:
+            force_safe_sku: bool | Force user SKU quote
             **kwargs:
 
         Returns:
             ApiResponse:
 
         """
+
+        if force_safe_sku:
+            #handle `forward slash` issue in SKU
+            seller_sku = quote_plus(seller_sku)
+
         kwargs.update(self._create_body(price, shipping_price, currency, is_fba, seller_sku, points, marketplace_id, optional_fulfillment_program))
         return self._request(fill_query_params(kwargs.pop('path'), seller_sku), data=kwargs)
 


### PR DESCRIPTION
ProductFees() api does not encript SKU containing forward slash as described here #431 

As SKU is part of URL some of the chars in SKU could yield issue with URL formatting so we get `SellingApiForbiddenException` due invalid URL

Fix should handle this behavior.  
Also there is option to disable this conversion if needed as I imagine there will be cases where this will be problematic.

Currently it will default to `True` so all SKU will be quoted. 

