### PR TITLE
Correct AplusContent

### DIFF
--- a/sp_api/api/aplus_content/aplus_content.py
+++ b/sp_api/api/aplus_content/aplus_content.py
@@ -1,5 +1,4 @@
 import urllib.parse
-
 from sp_api.base import Client, sp_endpoint, fill_query_params, ApiResponse
 
 
@@ -67,8 +66,8 @@ class AplusContent(Client):
         Returns:
             ApiResponse:
         """
-    
-        return self._request(kwargs.pop('path'),  data=kwargs)
+
+        return self._request(kwargs.pop('path'), data=kwargs.pop('body'), params=kwargs, add_marketplace=False)
     
 
     @sp_endpoint('/aplus/2020-11-01/contentDocuments/{}', method='GET')
@@ -126,7 +125,7 @@ class AplusContent(Client):
             ApiResponse:
         """
     
-        return self._request(fill_query_params(kwargs.pop('path'), contentReferenceKey), data=kwargs)
+        return self._request(fill_query_params(kwargs.pop('path'), contentReferenceKey), data=kwargs.pop("body"), params=kwargs, add_marketplace=False)
     
 
     @sp_endpoint('/aplus/2020-11-01/contentDocuments/{}/asins', method='GET')
@@ -184,7 +183,7 @@ class AplusContent(Client):
             ApiResponse:
         """
     
-        return self._request(fill_query_params(kwargs.pop('path'), contentReferenceKey), data=kwargs)
+        return self._request(fill_query_params(kwargs.pop('path'), contentReferenceKey), data=kwargs.pop("body"), params=kwargs, add_marketplace=False)
     
 
     @sp_endpoint('/aplus/2020-11-01/contentAsinValidations', method='POST')
@@ -212,8 +211,8 @@ class AplusContent(Client):
         Returns:
             ApiResponse:
         """
-    
-        return self._request(kwargs.pop('path'),  data=kwargs)
+
+        return self._request(kwargs.pop('path'), data=kwargs.pop("body"), params=kwargs, add_marketplace=False)
     
 
     @sp_endpoint('/aplus/2020-11-01/contentPublishRecords', method='GET')
@@ -241,7 +240,7 @@ class AplusContent(Client):
             ApiResponse:
         """
     
-        return self._request(kwargs.pop('path'),  params=kwargs)
+        return self._request(kwargs.pop('path'), params=kwargs)
     
 
     @sp_endpoint('/aplus/2020-11-01/contentDocuments/{}/approvalSubmissions', method='POST')
@@ -268,7 +267,7 @@ class AplusContent(Client):
             ApiResponse:
         """
     
-        return self._request(fill_query_params(kwargs.pop('path'), contentReferenceKey), data=kwargs)
+        return self._request(fill_query_params(kwargs.pop('path'), contentReferenceKey), params=kwargs)
     
 
     @sp_endpoint('/aplus/2020-11-01/contentDocuments/{}/suspendSubmissions', method='POST')
@@ -296,4 +295,3 @@ class AplusContent(Client):
         """
     
         return self._request(fill_query_params(kwargs.pop('path'), contentReferenceKey), data=kwargs)
-

--- a/sp_api/api/upload/upload.py
+++ b/sp_api/api/upload/upload.py
@@ -1,12 +1,12 @@
 from sp_api.base import Client, sp_endpoint
 from sp_api.base.helpers import create_md5, fill_query_params
-import hashlib
+import urllib.parse
+
 
 class Upload(Client):
     @sp_endpoint('/uploads/2020-11-01/uploadDestinations/{}', method='POST')
     def upload_document(self, resource, file, content_type='application/pdf', **kwargs):
-        md5 = create_md5(file)
-
+        md5 = urllib.parse.quote(create_md5(file))
         kwargs.update({
             'contentMD5': md5,
             'contentType': kwargs.pop('contentType', content_type),

--- a/sp_api/base/helpers.py
+++ b/sp_api/base/helpers.py
@@ -3,7 +3,6 @@ import hashlib
 import base64
 import warnings
 import functools
-import logging
 
 
 def fill_query_params(query, *args):


### PR DESCRIPTION
While trying the Upload api found that the endpoints of the apluscontent had problems because:

**1)aplus_content.py**

- The key marketplaceId:string | * REQUIRED is a required param so no need the add_marketplace which by default in the client is True
- The endpoints that need  post data as json body should be isolated so just pop it first and pass the left as params:
return self._request(kwargs.pop('path'), data=kwargs.pop("body"), params=kwargs, add_marketplace=False)
- The post_content_document_approval_submission need to be passed as params not data (think it will need to correct in the post_content_document_suspend_submission but I did not tried yet)

**2)upload.py**
Related with that when you tried to upload some image for the Aplus content in some special cases the md5 calculated could contain a + character that will crash the query so I need to quote it to made it work:
md5 = urllib.parse.quote(create_md5(file)) 

**3) helpers.py**
Remove unused import I had just for my testing the md5 issues
import logging

After that, you can use the sp-api and create from pure python code a A+ content.
Seems I was the first to do it ; )