### PR TITLE
Add new Orders endpoint update_shipment_status

### DIFF
--- a/sp_api/api/orders/orders.py
+++ b/sp_api/api/orders/orders.py
@@ -266,7 +266,7 @@ class Orders(Client):
         Returns:
             ApiResponse
         """
-        return self._request(fill_query_params(kwargs.pop('path'), order_id), data=kwargs)
+        return self._request(fill_query_params(kwargs.pop('path'), order_id), res_no_data=True, data=kwargs)
 
     @sp_endpoint('/tokens/2021-03-01/restrictedDataToken', method='POST')
     def _get_token(self, **kwargs):

--- a/sp_api/api/orders/orders.py
+++ b/sp_api/api/orders/orders.py
@@ -234,6 +234,40 @@ class Orders(Client):
         """
         return self._request(fill_query_params(kwargs.pop('path'), order_id), params=kwargs)
 
+    @sp_endpoint('/orders/v0/orders/{}/shipment', method='POST')
+    def update_shipment_status(self, order_id: str, **kwargs) -> ApiResponse:
+        """
+        update_shipment_status(self, order_id: str, **kwargs) -> ApiResponse
+
+        Update the shipment status.
+
+        **Usage Plan:**
+
+        ======================================  ==============
+        Rate (requests per second)               Burst
+        ======================================  ==============
+        5                                       15
+        ======================================  ==============
+
+        For more information, see "Usage Plans and Rate Limits" in the Selling Partner API documentation.
+
+        Examples:
+            literal blocks::
+
+                Orders().update_shipment_status(
+                    order_id='123-1234567-1234567',
+                    marketplaceId='ATVPDKIKX0DER',
+                    shipmentStatus='ReadyForPickup'
+                )
+
+        Args:
+            order_id: str
+
+        Returns:
+            ApiResponse
+        """
+        return self._request(fill_query_params(kwargs.pop('path'), order_id), data=kwargs)
+
     @sp_endpoint('/tokens/2021-03-01/restrictedDataToken', method='POST')
     def _get_token(self, **kwargs):
         data_elements = kwargs.pop('RestrictedResources')

--- a/sp_api/base/client.py
+++ b/sp_api/base/client.py
@@ -110,7 +110,7 @@ class Client(BaseClient):
                         )
 
     def _request(self, path: str, *, data: dict = None, params: dict = None, headers=None,
-                 add_marketplace=True) -> ApiResponse:
+                 add_marketplace=True, res_no_data: bool = False) -> ApiResponse:
         if params is None:
             params = {}
         if data is None:
@@ -127,10 +127,10 @@ class Client(BaseClient):
                       headers=headers or self.headers,
                       auth=self._sign_request(),
                       proxies=self.proxies)
-        return self._check_response(res)
+        return self._check_response(res, res_no_data)
 
-    def _check_response(self, res) -> ApiResponse:
-        if self.method == 'DELETE' and 200 <= res.status_code < 300:
+    def _check_response(self, res, res_no_data) -> ApiResponse:
+        if (self.method == 'DELETE' or res_no_data) and 200 <= res.status_code < 300:
             try:
                 js = res.json() or {}
             except JSONDecodeError:

--- a/tests/api/orders/test_orders.py
+++ b/tests/api/orders/test_orders.py
@@ -68,3 +68,15 @@ def test_get_order_api_response_call2():
     assert res.errors is None
     assert res.payload.get('AmazonOrderId') is not None
 
+
+def test_update_shipment_status_400_error():
+    from sp_api.base import SellingApiBadRequestException
+    try:
+        Orders().update_shipment_status(
+            order_id='123-1234567-1234567',
+            marketplaceId='1',
+            shipmentStatus='ReadyForPickup'
+        )
+    except SellingApiBadRequestException as sep:
+        assert sep.code == 400
+        assert sep.amzn_code == 'InvalidInput'

--- a/tests/api/orders/test_orders.py
+++ b/tests/api/orders/test_orders.py
@@ -69,6 +69,18 @@ def test_get_order_api_response_call2():
     assert res.payload.get('AmazonOrderId') is not None
 
 
+def test_update_shipment_status():
+    res = Orders().update_shipment_status(
+        order_id='123-1234567-1234567',
+        marketplaceId='ATVPDKIKX0DER',
+        shipmentStatus='ReadyForPickup'
+    )
+    assert res() is not None
+    assert isinstance(res(), dict)
+    assert res.errors is None
+    assert res.payload.get("status_code") == 204
+
+
 def test_update_shipment_status_400_error():
     from sp_api.base import SellingApiBadRequestException
     try:


### PR DESCRIPTION
New endpoint returns no data. Hence, had to introduce new optional parameter on _check_response to allow for that. Might be useful for future endpoints that return no data.