### PR TITLE
Update to allow custom endpoint version for Catalog

### DIFF
--- a/sp_api/api/catalog/catalog.py
+++ b/sp_api/api/catalog/catalog.py
@@ -9,8 +9,8 @@ class Catalog(Client):
 
     """
 
-    @sp_endpoint('/catalog/v0/items/{}')
-    def get_item(self, asin: str, **kwargs) -> ApiResponse:
+    @sp_endpoint('/catalog/{}/items/{}')
+    def get_item(self, asin: str, endpoint_version="v0", **kwargs) -> ApiResponse:
         """
         get_item(self, asin: str, **kwargs) -> ApiResponse
         Returns a specified item and its attributes.
@@ -32,18 +32,19 @@ class Catalog(Client):
 
         Args:
             asin: str
+            endpoint_version: str
             key MarketplaceId: str
             **kwargs:
 
         Returns:
             GetCatalogItemResponse:
         """
-        return self._request(fill_query_params(kwargs.pop('path'), asin), params=kwargs)
+        return self._request(fill_query_params(kwargs.pop('path'), endpoint_version, asin), params=kwargs)
 
-    @sp_endpoint('/catalog/v0/items')
-    def list_items(self, **kwargs) -> ApiResponse:
+    @sp_endpoint('/catalog/{}/items')
+    def list_items(self, endpoint_version="v0", **kwargs) -> ApiResponse:
         """
-        list_items(self, **kwargs) -> ApiResponse
+        list_items(self, endpoint_version:str, **kwargs) -> ApiResponse
         Returns a list of items and their attributes, based on a search query or item identifiers that you specify. When based on a search query, provide the Query parameter and optionally, the QueryContextId parameter. When based on item identifiers, provide a single appropriate parameter based on the identifier type, and specify the associated item value. MarketplaceId is always required.
 
         **Usage Plan:**
@@ -63,6 +64,7 @@ class Catalog(Client):
                 res = Catalog().list_items(MarketplaceId='TEST_CASE_200', SellerSKU='SKU_200')
 
         Args:
+            endpoint_version: str
             key MarketplaceId: str
             key Query: str
             key QueryContextId: str
@@ -77,7 +79,7 @@ class Catalog(Client):
         """
         if 'Query' in kwargs:
             kwargs.update({'Query': urllib.parse.quote_plus(kwargs.pop('Query'))})
-        return self._request(kwargs.pop('path'), params=kwargs)
+        return self._request(fill_query_params(kwargs.pop('path'), endpoint_version), params=kwargs)
 
     @sp_endpoint('/catalog/v0/categories')
     def list_categories(self, **kwargs) -> ApiResponse:


### PR DESCRIPTION
Issue is related to deprecated v0 endpoints as per info provided [here](https://developer-docs.amazon.com/sp-api/changelog/sp-api-throttling-adjustments)

`The Catalog Items v0 operations listCatalogItems (GET /catalog/v0/items) and getCatalogItem (GET /catalog/v0/items/{asin}) will be deprecated on September 30, 2022.`

This change will add option to call specific endpoint version (as we currently default on `v0` and there are two new versions currently active [3 in total])