### PR TITLE
Added GetItemOffersBatchRequest

### DIFF
--- a/sp_api/api/products/products.py
+++ b/sp_api/api/products/products.py
@@ -207,9 +207,10 @@ class Products(Client):
         return self._request(fill_query_params(kwargs.pop('path'), asin), params={**kwargs})
 
     @sp_endpoint('/batches/products/pricing/v0/itemOffers', method='POST')
-    def get_item_offers_batch(self, requests: Optional[List[Dict]] = None, **kwargs) -> ApiResponse:
+    def get_item_offers_batch(self, requests_: Optional[Union[List[Dict], GetItemOffersBatchRequest]] = None,
+                              **kwargs) -> ApiResponse:
         """
-        get_item_offers_batch(self, requests: Optional[List[Union[Dict, ItemOffersRequest]]], **kwargs) -> ApiResponse
+        get_item_offers_batch(self, requests_: Optional[List[Union[Dict, ItemOffersRequest]]], **kwargs) -> ApiResponse
         Returns the lowest priced offers for a batch of items based on ASIN.
 
         **Usage Plan:**
@@ -221,16 +222,20 @@ class Products(Client):
         ======================================  ==============
 
         Args:
-            requests: Optional (Body) [dict] The request associated with the getItemOffersBatch API call.
+            requests_: Optional (Body) [dict] The request associated with the getItemOffersBatch API call.
 
 
         Returns:
             ApiResponse
 
         """
-        get_item_offers_batch_request = GetItemOffersBatchRequest(requests=requests)
+        if isinstance(requests_, GetItemOffersBatchRequest):
+            get_item_offers_batch_request = requests_.to_dict()
+        else:
+            get_item_offers_batch_request = {"requests": requests_}
 
-        return self._request(kwargs.pop('path'), data=get_item_offers_batch_request.to_dict(), params={**kwargs})
+        return self._request(kwargs.pop('path'), data=get_item_offers_batch_request, params={**kwargs},
+                             add_marketplace=False)
 
     def _create_get_pricing_request(self, item_list, item_type, **kwargs):
         return self._request(kwargs.pop('path'),

--- a/sp_api/api/products/products.py
+++ b/sp_api/api/products/products.py
@@ -1,6 +1,8 @@
+from typing import Optional, List, Dict, Union
 import urllib.parse
 
 from sp_api.base import ApiResponse, Client, fill_query_params, sp_endpoint
+from sp_api.api.products.products_definitions import GetItemOffersBatchRequest, ItemOffersRequest
 
 
 class Products(Client):
@@ -204,6 +206,32 @@ class Products(Client):
 
         return self._request(fill_query_params(kwargs.pop('path'), asin), params={**kwargs})
 
+    @sp_endpoint('/batches/products/pricing/v0/itemOffers', method='POST')
+    def get_item_offers_batch(self, requests: Optional[List[Dict]] = None, **kwargs) -> ApiResponse:
+        """
+        get_item_offers_batch(self, requests: Optional[List[Union[Dict, ItemOffersRequest]]], **kwargs) -> ApiResponse
+        Returns the lowest priced offers for a batch of items based on ASIN.
+
+        **Usage Plan:**
+
+        ======================================  ==============
+        Rate (requests per second)               Burst
+        ======================================  ==============
+        .5                                       1
+        ======================================  ==============
+
+        Args:
+            requests: Optional (Body) [dict] The request associated with the getItemOffersBatch API call.
+
+
+        Returns:
+            ApiResponse
+
+        """
+        get_item_offers_batch_request = GetItemOffersBatchRequest(requests=requests)
+
+        return self._request(kwargs.pop('path'), data=get_item_offers_batch_request.to_dict(), params={**kwargs})
+
     def _create_get_pricing_request(self, item_list, item_type, **kwargs):
         return self._request(kwargs.pop('path'),
                              params={**{f"{item_type}s": ','.join(
@@ -216,3 +244,4 @@ class Products(Client):
                                      **({'OfferType': kwargs.pop(
                                          'OfferType')} if 'OfferType' in kwargs else {}),
                                      'MarketplaceId': kwargs.get('MarketplaceId', self.marketplace_id)})
+

--- a/sp_api/api/products/products_definitions.py
+++ b/sp_api/api/products/products_definitions.py
@@ -1,0 +1,43 @@
+from typing import Optional, List, Dict, Union
+from dataclasses import dataclass, asdict
+
+
+@dataclass
+class ItemOffersRequest:
+    """ Implements definition: https://developer-docs.amazon.com/sp-api/docs/product-pricing-api-v0-reference
+    #itemoffersrequest """
+    uri: str
+    method: str
+    MarketplaceId: str
+    ItemCondition: str
+    headers: Dict = None
+    CustomerType: str = None
+
+
+@dataclass
+class GetItemOffersBatchRequest:
+    """ Implements definition: https://developer-docs.amazon.com/sp-api/docs/product-pricing-api-v0-reference
+    #getitemoffersbatchrequest """
+    requests: Optional[List[Union[ItemOffersRequest, Dict]]] = None
+
+    def __post_init__(self):
+        self.requests = self.parse_requests(self.requests)
+
+    def to_dict(self):
+        return asdict(self)
+
+    @staticmethod
+    def parse_requests(requests) -> List[ItemOffersRequest]:
+        parsed_requestes = []
+
+        for request in requests:
+            if isinstance(request, Dict):
+                request = ItemOffersRequest(**request)
+
+            if not isinstance(request, ItemOffersRequest):
+                raise TypeError
+
+            parsed_requestes.append(request)
+
+        return parsed_requestes
+

--- a/sp_api/api/products/products_definitions.py
+++ b/sp_api/api/products/products_definitions.py
@@ -9,9 +9,9 @@ class ItemOffersRequest:
     uri: str
     method: str
     MarketplaceId: str
-    ItemCondition: str
-    headers: Dict = None
+    ItemCondition: str = None
     CustomerType: str = None
+    headers: Dict = None
 
 
 @dataclass

--- a/tests/api/products/test_products.py
+++ b/tests/api/products/test_products.py
@@ -27,3 +27,8 @@ def test_competitive_pricing_for_sku():
 def test_competitive_pricing_for_asin():
     res = Products().get_competitive_pricing_for_asins([], MarketplaceId="ATVPDKIKX0DER")
     assert res.payload[0].get('status') == 'Success'
+
+
+def test_get_item_offers_batch():
+    res = Products().get_item_offers_batch([], MarketplaceId="ATVPDKIKX0DER")
+    assert res.payload[0].get('status') == 'Success'

--- a/tests/api/products/test_products.py
+++ b/tests/api/products/test_products.py
@@ -30,5 +30,5 @@ def test_competitive_pricing_for_asin():
 
 
 def test_get_item_offers_batch():
-    res = Products().get_item_offers_batch([], MarketplaceId="ATVPDKIKX0DER")
+    res = Products().get_item_offers_batch([])
     assert res.payload[0].get('status') == 'Success'


### PR DESCRIPTION
The initial idea for addressing Batch operations, on [/batches/products/pricing/v0/itemOffers](https://developer-docs.amazon.com/sp-api/docs/product-pricing-api-v0-reference#getitemoffersbatch) endpoint.

So the main idea is to:
1. Create request definitions, since batch requests (in our case [GetItemOffersBatchRequest](https://developer-docs.amazon.com/sp-api/docs/product-pricing-api-v0-reference#getitemoffersbatchrequest)) are not explicitly stated in sp_api.api.products.products.Products.get_item_offers_batch function.
2. Allow as input request definition class or Python base types `requests_: Optional[Union[List[Dict], GetItemOffersBatchRequest]] = None`.

The main problem is that one has to state directly `"MarketplaceId"` in list of requests, but addressing that will require changing `self._request`.

Exemplary use:

```
products_api.get_item_offers_batch([
        {
            "uri": "/products/pricing/v0/items/AAABBBCCCD/offers",
            "method": "GET",
            "MarketplaceId": "A1PA6795UKMFR9"
        }
    ])
```