### PR TITLE
Add SellingApiNotFoundException to get_exception_for_code

### DIFF
--- a/sp_api/base/__init__.py
+++ b/sp_api/base/__init__.py
@@ -10,6 +10,9 @@ from .exceptions import SellingApiForbiddenException
 from .exceptions import SellingApiRequestThrottledException
 from .exceptions import SellingApiServerException
 from .exceptions import SellingApiTemporarilyUnavailableException
+from .exceptions import SellingApiTooLargeException
+from .exceptions import SellingApiStateConflictException
+from .exceptions import SellingApiUnsupportedFormatException
 from .schedules import Schedules
 from .report_status import ReportStatus
 from .sales_enum import FirstDayOfWeek, Granularity, BuyerType
@@ -42,10 +45,14 @@ __all__ = [
     'SellingApiException',
     'SellingApiBadRequestException',
     'SellingApiNotFoundException',
+    'SellingApiServerException',
     'SellingApiForbiddenException',
     'SellingApiBadRequestException',
     'SellingApiRequestThrottledException',
     'SellingApiTemporarilyUnavailableException',
+    'SellingApiTooLargeException',
+    'SellingApiStateConflictException',
+    'SellingApiUnsupportedFormatException',
     'Schedules',
     'ReportStatus',
     'FirstDayOfWeek',

--- a/sp_api/base/exceptions.py
+++ b/sp_api/base/exceptions.py
@@ -51,6 +51,36 @@ class SellingApiNotFoundException(SellingApiException):
         super(SellingApiNotFoundException, self).__init__(error, headers)
 
 
+class SellingApiStateConflictException(SellingApiException):
+    """
+    409	The resource specified conflicts with the current state.
+    """
+    code = 409
+
+    def __init__(self, error, headers=None):
+        super(SellingApiStateConflictException, self).__init__(error, headers)
+
+
+class SellingApiTooLargeException(SellingApiException):
+    """
+    413	The request size exceeded the maximum accepted size.
+    """
+    code = 413
+
+    def __init__(self, error, headers=None):
+        super(SellingApiTooLargeException, self).__init__(error, headers)
+
+
+class SellingApiUnsupportedFormatException(SellingApiException):
+    """
+    415	The request payload is in an unsupported format.
+    """
+    code = 415
+
+    def __init__(self, error, headers=None):
+        super(SellingApiUnsupportedFormatException, self).__init__(error, headers)
+
+
 class SellingApiRequestThrottledException(SellingApiException):
     """
     429	The frequency of requests was greater than allowed.
@@ -100,6 +130,9 @@ def get_exception_for_code(code: int):
         400: SellingApiBadRequestException,
         403: SellingApiForbiddenException,
         404: SellingApiNotFoundException,
+        409: SellingApiStateConflictException,
+        413: SellingApiTooLargeException,
+        415: SellingApiUnsupportedFormatException,
         429: SellingApiRequestThrottledException,
         500: SellingApiServerException,
         503: SellingApiTemporarilyUnavailableException,

--- a/sp_api/base/exceptions.py
+++ b/sp_api/base/exceptions.py
@@ -99,6 +99,7 @@ def get_exception_for_code(code: int):
     return {
         400: SellingApiBadRequestException,
         403: SellingApiForbiddenException,
+        404: SellingApiNotFoundException,
         429: SellingApiRequestThrottledException,
         500: SellingApiServerException,
         503: SellingApiTemporarilyUnavailableException,


### PR DESCRIPTION
SellingApiNotFoundException wasn't in the list so 404s weren't being raised properly.  Also adds a few missing error types while we're at it.