### PR TITLE
Implement bulk call for ProductFees

### DIFF
--- a/sp_api/api/product_fees/product_fees.py
+++ b/sp_api/api/product_fees/product_fees.py
@@ -95,6 +95,47 @@ class ProductFees(Client):
         kwargs.update(self._create_body(price, shipping_price, currency, is_fba, asin, points, marketplace_id, optional_fulfillment_program))
         return self._request(fill_query_params(kwargs.pop('path'), asin), data=kwargs)
 
+
+    def get_product_fees_estimate(self, estimate_requests: list[dict]) -> ApiResponse:
+        """
+        get_product_fees_estimate(self, estimate_requests: list[dict]) -> ApiResponse
+
+        Return fees for multiple products
+
+        Examples:
+            literal blocks::
+
+                ProductFees().get_product_fees_estimate(
+                        [
+                            dict(id_type='ASIN', id_value='B012345678', price=100),
+                            dict(id_type='ASIN', id_value='B012345678', price=50, is_fba=True),
+                        ]
+                    )
+
+
+        Args:
+            estimate_requests: list of dict where the allowed keys are :
+                id_type: str | ASIN or SellerSKU
+                id_value: str
+                price:
+                currency:
+                shipping_price:
+                is_fba:
+                points:
+                marketplace_id: str | Defaults to self.marketplace_id
+                optional_fulfillment_program:
+        """
+        data = [
+            dict(
+                IdType = er.pop('id_type'),
+                IdValue = er.pop('id_value'),
+                **self._create_body(**er)
+            )
+            for er in estimate_requests
+        ]
+        return self._request('/products/fees/v0/feesEstimate', data=data, params=dict(method='POST'), wrap_list=True)
+
+
     def _create_body(self, price, shipping_price=None, currency='USD', is_fba=False, identifier=None,
                      points: dict = None, marketplace_id: str = None, optional_fulfillment_program: str=None):
         """
@@ -130,3 +171,10 @@ class ProductFees(Client):
                 'MarketplaceId': marketplace_id or self.marketplace_id
             }
         }
+
+
+    def _add_marketplaces(self, data):
+        # MarketplaceID is a property of the body's FeesEstimateRequest for this section, and does
+        # not need to be added. Additionally, Client._add_marketplaces will fail as it assumes
+        # data is a dict, which is not the case for get_product_fees_estimate.
+        pass

--- a/tests/api/product_fees/product_fees.py
+++ b/tests/api/product_fees/product_fees.py
@@ -1,5 +1,3 @@
-import urllib.parse
-
 from sp_api.api import ProductFees
 from sp_api.base import Marketplaces
 
@@ -26,3 +24,26 @@ def test_get_fees_for_asin():
                                                                }
                                                            })
     assert res.payload.get('FeesEstimateResult').get('Status') == 'Success'
+
+
+def test_get_product_fees_estimate():
+    res = ProductFees().get_product_fees_estimate([
+            dict(identifier='UmaS1',id_type='ASIN',id_value="asin123", price=10, currency='USD', shipping_price=10, is_fba=False,
+                points={
+                    "PointsNumber": 0,
+                    "PointsMonetaryValue": {
+                        "CurrencyCode": "USD",
+                        "Amount": 0
+                    }}
+                ),
+            dict(identifier='UmaS2', marketplace_id=Marketplaces.MX.marketplace_id, id_type='SellerSKU', id_value="sku123", price=10, currency='MXN', shipping_price=10, is_fba=True,
+                points={
+                    "PointsNumber": 0,
+                    "PointsMonetaryValue": {
+                        "CurrencyCode": "MXN",
+                        "Amount": 0
+                    }}
+                ),
+        ])
+    for fer in res.payload:
+        assert fer['Status'] == 'Success'


### PR DESCRIPTION
This call, `POST /products/fees/v0/feesEstimate`, is unique among all other implemented calls in that its request and response bodies are arrays (of objects) at the top level; everything else has an object. This wouldn't work as parts of `Client` assume that the request is a dictionary, hence the addition of `wrap_lists`. This isn't perfect, as unfortunately `Client` actually treats `data` as both the request body _and_ metadata about the request, such as HTTP method. There may be a better solution that doesn't involve massive refactoring, but this is a fairly small change and does work for this use case.

A couple notes on the tests:
1. There are a few issues with the sandbox for the product fee calls. The first is that `OptionalFulfillmentProgram` cannot be `null`, failing validation; the production endpoint has no problem with this. The second is that the sandbox for this newly implemented call appears to be broken, in that it does not accept the dummy request body as given in the spec.
2. `product_fees.py` should be named `test_product_fees.py`. The current name means test discovery, for example in the CI, does not see it.

Because of note 1, I decided not to fix note 2. Currently the tests will fail anyway, including the ones that weren't touched by this commit. I waffled about this for a while and figured it's ok that they are skipped, as the sandbox appears to be misbehaving.