### PR TITLE
IdentifiersTypes for v2022-04-01

### DIFF
--- a/sp_api/base/identifiersType.py
+++ b/sp_api/base/identifiersType.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class IdentifiersType(str, Enum):
+    ASIN = 'ASIN'       # Amazon Standard Identification Number.
+    EAN = 'EAN'         # European Article Number.
+    GTIN = 'GTIN'       # Global Trade Item Number.
+    ISBN = 'ISBN'       # International Standard Book Number.
+    JAN = 'JAN'         # Japanese Article Number.
+    MINSAN = 'MINSAN'   # Minsan Code.
+    SKU = 'SKU'         # Stock Keeping Unit, a seller-specified identifier for an Amazon listing. Note: Must be accompanied by sellerId.
+    UPC = 'UPC'         # Universal Product Code.


### PR DESCRIPTION
CatalogItems(self, **kwargs) -> ApiResponse
    See IdentifiersType  at
    :link: https://developer-docs.amazon.com/sp-api/docs/catalog-items-api-v2022-04-01-reference#identifierstype
    
IdentifiersType required with identifiers(Max count : 20)
“Type of product identifiers to search the Amazon catalog for. Note: Required when identifiers are provided.”

```
        Examples:
            literal blocks::

		from sp_api.base.identifiersType import IdentifiersType

                res = CatalogItems().search_catalog_items(
				marketplace=Marketplaces.US,
				identifiers='B00XXX111,B00XXX112’,
				identifiersType=IdentifiersType.ASIN)
```


```
"/catalog/2022-04-01/items": {
      "get": {
        "tags": [
          "catalog"
        ],
        "operationId": "searchCatalogItems"
        "parameters": [
          {
            "name": "identifiers",
            "description": "A comma-delimited list of product identifiers to search the Amazon catalog for. **Note:** Cannot be used with `keywords`.",
            "in": "query",
            "required": false,
            "type": "array",
            "maxItems": 20,
            "items": {
              "type": "string"
            },
            "collectionFormat": "csv",
            "x-example": "shoes"
          },
          {
            "name": "identifiersType",
            "description": "Type of product identifiers to search the Amazon catalog for. **Note:** Required when `identifiers` are provided.",
            "in": "query",
            "required": false,
            "type": "string",
            "enum": [
              "ASIN",
              "EAN",
              "GTIN",
              "ISBN",
              "JAN",
              "MINSAN",
              "SKU",
              "UPC"
            ],
```