### PR TITLE
allow to use IAM user arn or IAM role arn.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ dmypy.json
 cython_debug/
 
 env.env
+.python-version

--- a/sp_api/base/client.py
+++ b/sp_api/base/client.py
@@ -64,10 +64,18 @@ class Client(BaseClient):
         ).hexdigest()
 
     def set_role(self, cache_key='role'):
-        role = self.boto3_client.assume_role(
-            RoleArn=self.credentials.role_arn,
-            RoleSessionName='guid'
-        )
+        *_, arn_resource = self.credentials.role_arn.split(":")
+        if arn_resource.startswith("user"):
+            role = self.boto3_client.get_session_token()
+        elif arn_resource.startswith("role"):
+            role = self.boto3_client.assume_role(
+                RoleArn=self.credentials.role_arn,
+                RoleSessionName='guid'
+            )
+        else:
+            raise ValueError(
+                "Invalid ARN, your ARN is not for a user or a role"
+            )
         role_cache[cache_key] = role
         return role
 

--- a/tests/client/test_base.py
+++ b/tests/client/test_base.py
@@ -85,6 +85,8 @@ def test_from_code_credential_provider_no_role_no_refresh_token():
 
 @pytest.mark.order(-2)
 def test_env_vars_provider():
+
+    previous_env = os.environ.copy()
     os.environ['SP_API_REFRESH_TOKEN'] = 'foo'
     os.environ['LWA_APP_ID'] = 'foo'
     os.environ['LWA_CLIENT_SECRET'] = 'foo'
@@ -95,12 +97,7 @@ def test_env_vars_provider():
     p = FromEnvironmentVariablesCredentialProvider()()
     assert 'refresh_token' in p
 
-    os.environ.pop('SP_API_REFRESH_TOKEN')
-    os.environ.pop('LWA_APP_ID')
-    os.environ.pop('LWA_CLIENT_SECRET')
-    os.environ.pop('SP_API_ACCESS_KEY')
-    os.environ.pop('SP_API_SECRET_KEY')
-    os.environ.pop('SP_API_ROLE_ARN')
+    os.environ = previous_env
 
 
 @pytest.mark.order(-1)

--- a/tests/client/test_base.py
+++ b/tests/client/test_base.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-
+from unittest.mock import MagicMock
 from sp_api.api import FulfillmentInbound
 from sp_api.base import AccessTokenClient
 from sp_api.base import Marketplaces, MissingCredentials, Client, SellingApiForbiddenException
@@ -185,3 +185,18 @@ def test_client():
         client._request_grantless_operation('')
     except SellingApiForbiddenException as e:
         assert isinstance(e, SellingApiForbiddenException)
+
+
+@pytest.mark.parametrize(
+    "specific_role",
+    ("arn:aws:iam::123:role/some-role", "arn:aws:iam::123:user/some-role")
+)
+def test_client_with_different_roles_arn(monkeypatch, specific_role):
+    client = Client()
+    monkeypatch.setattr(client, "boto3_client", MagicMock())
+
+    class FooCredentials:
+        role_arn = specific_role
+
+    monkeypatch.setattr(client, "credentials", FooCredentials())
+    assert client.set_role() is not None


### PR DESCRIPTION
The amazon sp-api integration allows to use IAM user entity or IAM role entity. [amazon documentation](https://developer-docs.amazon.com/sp-api/docs/creating-and-configuring-iam-policies-and-entities#step-5-add-an-aws-security-token-service-aws-sts-policy-to-your-iam-user)
if we use a user based arn we need to use another function from the boto3 client to get the required credentials role

This will allow to integrate with apps configured with user arn entity in the amazon seller central app.