### PR TITLE
add orders endpoint to update shipment status

### DIFF
--- a/sp_api/api/orders/orders.py
+++ b/sp_api/api/orders/orders.py
@@ -234,6 +234,32 @@ class Orders(Client):
         """
         return self._request(fill_query_params(kwargs.pop('path'), order_id), params=kwargs)
 
+    @sp_endpoint('/orders/v0/orders/{}/shipment', method='POST')
+    def update_shipment_status(self, order_id: str, **kwargs) -> ApiResponse:
+        """
+        update_shipment_status(self, order_id: str, **kwargs) -> ApiResponse
+        Update the shipment status.
+        **Usage Plan:**
+        ======================================  ==============
+        Rate (requests per second)               Burst
+        ======================================  ==============
+        5                                       15
+        ======================================  ==============
+        For more information, see "Usage Plans and Rate Limits" in the Selling Partner API documentation.
+        Examples:
+            literal blocks::
+                Orders().update_shipment_status(
+                    order_id='123-1234567-1234567',
+                    marketplaceId='ATVPDKIKX0DER',
+                    shipmentStatus='ReadyForPickup'
+                )
+        Args:
+            order_id: str
+        Returns:
+            ApiResponse
+        """
+        return self._request(fill_query_params(kwargs.pop('path'), order_id), res_no_data=True, data=kwargs)
+
     @sp_endpoint('/tokens/2021-03-01/restrictedDataToken', method='POST')
     def _get_token(self, **kwargs):
         data_elements = kwargs.pop('RestrictedResources')

--- a/tests/api/orders/test_orders.py
+++ b/tests/api/orders/test_orders.py
@@ -68,3 +68,27 @@ def test_get_order_api_response_call2():
     assert res.errors is None
     assert res.payload.get('AmazonOrderId') is not None
 
+
+def test_update_shipment_status():
+    res = Orders().update_shipment_status(
+        order_id='123-1234567-1234567',
+        marketplaceId='ATVPDKIKX0DER',
+        shipmentStatus='ReadyForPickup'
+    )
+    assert res() is not None
+    assert isinstance(res(), dict)
+    assert res.errors is None
+    assert res.payload.get("status_code") == 204
+
+
+def test_update_shipment_status_400_error():
+    from sp_api.base import SellingApiBadRequestException
+    try:
+        Orders().update_shipment_status(
+            order_id='123-1234567-1234567',
+            marketplaceId='1',
+            shipmentStatus='ReadyForPickup'
+        )
+    except SellingApiBadRequestException as sep:
+        assert sep.code == 400
+        assert sep.amzn_code == 'InvalidInput'


### PR DESCRIPTION
This PR adds the method to update_shipment_status for Amazon orders.