### PR TITLE
get_feed_result_document uses encoding returned by Amazon.

### DIFF
--- a/sp_api/api/feeds/feeds.py
+++ b/sp_api/api/feeds/feeds.py
@@ -223,7 +223,14 @@ class Feeds(Client):
         response = self._request(fill_query_params(kwargs.pop('path'), feedDocumentId), params=kwargs,
                                  add_marketplace=False)
         url = response.payload.get('url')
+        docResponse = requests.get(url)
+        content = docResponse.content
+
+        encoding = docResponse.encoding if docResponse.encoding else 'iso-8859-1'
+        if encoding.lower() == 'windows-31j':
+            encoding = 'cp932'
+
         content = requests.get(url).content
         if 'compressionAlgorithm' in response.payload:
-            return zlib.decompress(bytearray(content), 15 + 32).decode('iso-8859-1')
-        return content.decode('iso-8859-1')
+            return zlib.decompress(bytearray(content), 15 + 32).decode(encoding)
+        return content.decode(encoding)

--- a/tests/api/feeds/test_feeds.py
+++ b/tests/api/feeds/test_feeds.py
@@ -40,3 +40,9 @@ def test_request():
         Feeds()._request('', data={})
     except SellingApiForbiddenException:
         assert True
+
+
+def test_get_feed_document():
+    feed_document_id = '0356cf79-b8b0-4226-b4b9-0ee058ea5760'
+    res = Feeds().get_feed_document(feed_document_id)
+    assert 'TestSku102XmlParentã\x81\x8cã\x82\x93ã\x81°ã\x81£ã\x81¦' in res


### PR DESCRIPTION
Amazon returns various encodings on different venues:
US windows-1252
UK windows-1252
DE windows-1252
JP windows-31j
FR windows-1252
CA windows-1252
IT windows-1252
ES windows-1252
AU UTF-8
SG UTF-8
BR windows-1252
NL windows-1252