### PR TITLE
Don't double escape item IDs in product pricing requests

### DIFF
--- a/sp_api/api/products/products.py
+++ b/sp_api/api/products/products.py
@@ -239,8 +239,7 @@ class Products(Client):
 
     def _create_get_pricing_request(self, item_list, item_type, **kwargs):
         return self._request(kwargs.pop('path'),
-                             params={**{f"{item_type}s": ','.join(
-                                 [urllib.parse.quote_plus(s) for s in item_list])},
+                             params={**{f"{item_type}s": ','.join(item_list)},
                                      'ItemType': item_type,
                                      **({'ItemCondition': kwargs.pop(
                                          'ItemCondition')} if 'ItemCondition' in kwargs else {}),


### PR DESCRIPTION
This PR is similar to https://github.com/saleweaver/python-amazon-sp-api/pull/650 but for product pricing requests instead of `get_inventory_summary_marketplace`. 

Amazon doesn't recognize SKUs that contain spaces if they are encoded twice, which is the current behavior. The first encoding is due to `quote_plus()` and the second is due to the `requests` library. The `quote_plus` seems to be unnecessary since `requests` is already handling special characters.