### PR TITLE
Fix for SKUs containing commas

### DIFF
--- a/sp_api/api/products/products.py
+++ b/sp_api/api/products/products.py
@@ -238,7 +238,7 @@ class Products(Client):
 
     def _create_get_pricing_request(self, item_list, item_type, **kwargs):
         return self._request(kwargs.pop('path'),
-                             params={**{f"{item_type}s": ','.join(item_list)},
+                             params={**{f"{item_type}s": item_list},
                                      'ItemType': item_type,
                                      **({'ItemCondition': kwargs.pop(
                                          'ItemCondition')} if 'ItemCondition' in kwargs else {}),
@@ -247,4 +247,3 @@ class Products(Client):
                                      **({'OfferType': kwargs.pop(
                                          'OfferType')} if 'OfferType' in kwargs else {}),
                                      'MarketplaceId': kwargs.get('MarketplaceId', self.marketplace_id)})
-


### PR DESCRIPTION
Fix _create_get_pricing_request for SKUs containing commas.
SKUs may contain commas.
In this case they will be separated and 2 bugs are possible:
1) the number of SKUs after separation will exceed 20
2) incorrect SKUs will be passed in the request parameters
