### PR TITLE
BaseClient - Catch JSONDecodeError properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 A wrapper to access **Amazon's Selling Partner API** with an easy-to-use interface.
 
 
-
 ### Q & A
 
 If you have questions, please ask them in GitHub discussions 
@@ -35,7 +34,7 @@ pip install python-amazon-sp-api
 ---
 ### Usage
 
-```
+```python
 from sp_api.api import Orders
 from sp_api.api import Reports
 from sp_api.api import Feeds

--- a/sp_api/base/client.py
+++ b/sp_api/base/client.py
@@ -1,6 +1,5 @@
 import hashlib
 import json
-import re
 from datetime import datetime
 import logging
 import os
@@ -160,12 +159,15 @@ class Client(BaseClient):
             except JSONDecodeError:
                 js = {'status_code': res.status_code}
         else:
-            js = res.json() or {}
+            try:
+                js = res.json() or {}
+            except JSONDecodeError:
+                js = {}
 
         if isinstance(js, list):
             if wrap_list:
                 # Support responses that are an array at the top level, eg get_product_fees_estimate
-                js = dict(payload = js)
+                js = dict(payload=js)
             else:
                 js = js[0]
 


### PR DESCRIPTION
Avoid breaking the Client call if the response is not JSON serializable