### PR TITLE
Update reports.py

### DIFF
--- a/sp_api/api/reports/reports.py
+++ b/sp_api/api/reports/reports.py
@@ -398,7 +398,7 @@ class Reports(Client):
     @staticmethod
     def _handle_file(file, document, encoding):
         if isinstance(file, str):
-            with open(file, "w+", encoding=encoding) as text_file:
+            with open(file, "w+", encoding=encoding, newline="\n") as text_file:
                 text_file.write(document)
         elif isinstance(file, BytesIO):
             file.write(document.encode(encoding))


### PR DESCRIPTION
Updated _handle_file static method to resolve error whereby each row was separated by an empty line when downloading reports to file.

The outputted report now matches what could be obtained through Amazon Seller Central.