### PR TITLE
852 - Ensure credentials is instance of CredentialProvider

### DIFF
--- a/sp_api/auth/access_token_client.py
+++ b/sp_api/auth/access_token_client.py
@@ -7,7 +7,7 @@ import hashlib
 import logging
 from cachetools import TTLCache
 import boto3
-from sp_api.base import BaseClient
+from sp_api.base import BaseClient, CredentialProvider
 
 from .credentials import Credentials
 from .access_token_response import AccessTokenResponse
@@ -25,6 +25,8 @@ class AccessTokenClient(BaseClient):
     path = '/auth/o2/token'
 
     def __init__(self, refresh_token=None, credentials=None, proxies=None, verify=True):
+        if not isinstance(credentials, CredentialProvider):
+            raise TypeError('credentials must be instance of CredentialProvider')
         self.cred = Credentials(refresh_token, credentials)
         self.proxies = proxies
         self.verify = verify


### PR DESCRIPTION
Raises type error when `credentials` in `AccessTokenClient` is not an instance of `CredentialProvider`.

Closes #852 