### PR TITLE
feat: Allow injection of custom Credential Providers

### DIFF
--- a/sp_api/base/client.py
+++ b/sp_api/base/client.py
@@ -41,11 +41,16 @@ class Client(BaseClient):
             proxies=None,
             verify=True,
             timeout=None,
-            version=None
+            version=None,
+            credential_providers=None,
     ):
         if os.environ.get('SP_API_DEFAULT_MARKETPLACE', None):
             marketplace = Marketplaces[os.environ.get('SP_API_DEFAULT_MARKETPLACE')]
-        self.credentials = CredentialProvider(account, credentials).credentials
+        self.credentials = CredentialProvider(
+            account,
+            credentials,
+            credential_providers=credential_providers,
+        ).credentials
         boto_config = Config(
             proxies=proxies,
         )
@@ -134,7 +139,7 @@ class Client(BaseClient):
             data = {}
 
         # Note: The use of isinstance here is to support request schemas that are an array at the
-        # top level, eg get_product_fees_estimate 
+        # top level, eg get_product_fees_estimate
         self.method = params.pop('method', data.pop('method', 'GET') if isinstance(data, dict) else 'GET')
 
         if add_marketplace:

--- a/sp_api/base/credential_provider.py
+++ b/sp_api/base/credential_provider.py
@@ -1,5 +1,6 @@
 import json
 import os
+from typing import Dict, Iterable, Optional, Type
 
 import confuse
 import boto3
@@ -112,16 +113,22 @@ class CredentialProvider:
     credentials = None
     cache = Cache(maxsize=10)
 
-    CREDENTIAL_PROVIDERS = [
+    CREDENTIAL_PROVIDERS: Iterable[Type[BaseCredentialProvider]] = (
         FromCodeCredentialProvider,
         FromEnvironmentVariablesCredentialProvider,
         FromSecretsCredentialProvider,
         FromConfigFileCredentialProvider
-    ]
+    )
 
-    def __init__(self, account='default', credentials=None):
+    def __init__(
+        self,
+        account: str = 'default',
+        credentials: Optional[Dict[str, str]] = None,
+        credential_providers: Optional[Iterable[Type[BaseCredentialProvider]]] = None,
+    ):
         self.account = account
-        for cp in self.CREDENTIAL_PROVIDERS:
+        providers = self.CREDENTIAL_PROVIDERS if credential_providers is None else credential_providers
+        for cp in providers:
             try:
                 self.credentials = cp(account=account, credentials=credentials)()
                 break

--- a/tests/client/test_auth.py
+++ b/tests/client/test_auth.py
@@ -1,14 +1,15 @@
 from sp_api.base import AccessTokenClient
 from sp_api.base import Credentials, CredentialProvider
 from sp_api.base import AuthorizationError
-from sp_api.base.credential_provider import FromCodeCredentialProvider
+from sp_api.base.credential_provider import BaseCredentialProvider, FromCodeCredentialProvider
+
+
 refresh_token = '<refresh_token>'
 lwa_app_id = '<lwa_app_id>'
 lwa_client_secret = '<lwa_client_secret>'
 aws_secret_key = '<aws_secret_access_key>'
 aws_access_key = '<aws_access_key_id>'
 role_arn = '<role_arn>'
-
 
 
 def test_auth_exception():
@@ -20,10 +21,33 @@ def test_auth_exception():
 
 def test_credentials():
     x = CredentialProvider()
+    assert x.credentials is not None
     assert x.credentials.lwa_app_id is not None
     assert x.credentials.lwa_client_secret is not None
     assert x.credentials.aws_secret_key is not None
     assert x.credentials.aws_access_key is not None
+
+
+def test_credentials_with_custom_provider():
+    class CustomCredentialProvider(BaseCredentialProvider):
+        def load_credentials(self):
+            self.credentials = {
+                "refresh_token": refresh_token,
+                "lwa_app_id": lwa_app_id,
+                "lwa_client_secret": lwa_client_secret,
+                "aws_secret_key": aws_secret_key,
+                "aws_access_key": aws_access_key,
+                "role_arn": role_arn,
+            }
+
+    cp = CredentialProvider(credential_providers=(CustomCredentialProvider,))
+    assert cp.credentials is not None
+    assert cp.credentials.refresh_token == "<refresh_token>"
+    assert cp.credentials.lwa_app_id == "<lwa_app_id>"
+    assert cp.credentials.lwa_client_secret == "<lwa_client_secret>"
+    assert cp.credentials.aws_secret_key == "<aws_secret_access_key>"
+    assert cp.credentials.aws_access_key == "<aws_access_key_id>"
+    assert cp.credentials.role_arn == "<role_arn>"
 
 
 def test_auth_client():


### PR DESCRIPTION
Currently, the `CredentialProvider` constructor uses its own iterable of providers to retrieve and instantiate credentials. However, there are two challenges with the current approach:

* Reducing the list of default providers, to only include the ones that a specific deployment uses can only be done by mutating the `CredentialProvider.CREDENTIAL_PROVIDERS` list.
* Adding new, custom providers, or extending existing ones, is not possible.

This change allows users to implement and provide their own providers, or only provide the ones they are interested in, to be used.