### PR TITLE
misc: Remove six dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pytest
 requests~=2.28.1
-six>=1.15,<2
 boto3~=1.26.39
 cachetools~=5.2.0
 setuptools~=65.6.3

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ setup(
     version=__version__,
     install_requires=[
         "requests",
-        "six>=1.15,<2",
         "boto3>=1.16.39,<2",
         "cachetools>=4.2,<5.3",
         "pytz",


### PR DESCRIPTION
`six` is no longer being used within the codebase, and is not needed as the project does not support Python 2 anymore.