### PR TITLE
feat: Add support for aws-secretsmanager-caching-python library

### DIFF
--- a/docs/env_variables.rst
+++ b/docs/env_variables.rst
@@ -2,16 +2,17 @@ Environment Variables
 =====================
 
 
-=====================    =========================================================================================================
+=====================    =============================================================================================================================================================================================
 ENVIRONMENT VARIABLE     DESCRIPTION
-=====================    =========================================================================================================
+=====================    =============================================================================================================================================================================================
 SP_API_REFRESH_TOKEN     The refresh token used obtained via authorization (can be passed to the client instead)
 LWA_APP_ID               Your login with amazon app id
 LWA_CLIENT_SECRET        Your login with amazon client secret
 SP_API_ACCESS_KEY        AWS USER ACCESS KEY
 SP_API_SECRET_KEY        AWS USER SECRET KEY
 SP_API_ROLE_ARN          The role's arn (needs permission to "Assume Role" STS)
-=====================    =========================================================================================================
+SP_API_AWS_SECRET_ID     Secret id from AWS Secrets Manager, which includes the following keys: `SP_API_REFRESH_TOKEN`, `LWA_APP_ID`, `LWA_CLIENT_SECRET`, `SP_API_ACCESS_KEY`, `SP_API_SECRET_KEY`, `SP_API_ROLE_ARN`
+=====================    =============================================================================================================================================================================================
 
 
 To set environment variables under linux/mac, use
@@ -47,9 +48,21 @@ You can use every account's name
 
     Orders(account='ANOTHER_ACCOUNT').get_orders(CreatedAfter=(datetime.utcnow() - timedelta(days=7)).isoformat())
 
-**************************
+
+******************************
+Usage with AWS Secrets Manager
+******************************
+
+The required credentials can be retrieved from a secret in AWS Secrets Manager, by setting the `SP_API_AWS_SECRET_ID`
+environment variable.
+
+If the `aws-secretsmanager-caching-python`_ library is installed, it will be used to temporarily cache the retrieved
+secret contents, and reduce calls to AWS Secrets Manager.
+
+
+****
 Note
-**************************
+****
 
 The refresh token can be passed directly to the client, too. You don't need to pass the whole credentials if all that changes is the refresh token.
 
@@ -57,3 +70,11 @@ The refresh token can be passed directly to the client, too. You don't need to p
 
     Orders(account='ANOTHER_ACCOUNT', refresh_token='<refresh_token_for_this_request>').get_orders(CreatedAfter=(datetime.utcnow() - timedelta(days=7)).isoformat())
 
+
+**********
+References
+**********
+
+.. target-notes::
+
+.. _`aws-secretsmanager-caching-python`: https://github.com/aws/aws-secretsmanager-caching-python

--- a/tests/client/test_credential_provider.py
+++ b/tests/client/test_credential_provider.py
@@ -1,0 +1,54 @@
+import os
+from unittest import mock
+
+from sp_api.base.credential_provider import FromCachedSecretsCredentialProvider
+
+
+REFRESH_TOKEN = '<refresh_token>'
+LWA_APP_ID = '<lwa_app_id>'
+LWA_CLIENT_SECRET = '<lwa_client_secret>'
+AWS_SECRET_KEY = '<aws_secret_access_key>'
+AWS_ACCESS_KEY = '<aws_access_key_id>'
+ROLE_ARN = '<role_arn>'
+
+
+def test_from_cached_secrets_cp_without_secret_id_set():
+    with mock.patch.dict(os.environ, {"SP_API_AWS_SECRET_ID": ""}):
+        cp = FromCachedSecretsCredentialProvider()
+        cp.load_credentials()
+
+    assert cp.credentials is None
+
+
+def test_from_cached_secrets_cp_without_cache_available():
+    with mock.patch.dict(os.environ, {"SP_API_AWS_SECRET_ID": "test"}), \
+            mock.patch.object(FromCachedSecretsCredentialProvider, "_get_secret_cache", return_value=None):
+        cp = FromCachedSecretsCredentialProvider()
+        cp.load_credentials()
+
+    assert cp.credentials is None
+
+
+def test_from_cached_secrets_cp_with_cache_available():
+    secret_content = {
+        "SP_API_REFRESH_TOKEN": REFRESH_TOKEN,
+        "LWA_APP_ID": LWA_APP_ID,
+        "LWA_CLIENT_SECRET": LWA_CLIENT_SECRET,
+        "SP_API_ACCESS_KEY": AWS_ACCESS_KEY,
+        "SP_API_SECRET_KEY": AWS_SECRET_KEY,
+        "SP_API_ROLE_ARN": ROLE_ARN,
+    }
+
+    with mock.patch.dict(os.environ, {"SP_API_AWS_SECRET_ID": "test"}), \
+            mock.patch.object(FromCachedSecretsCredentialProvider, "get_secret_content", return_value=secret_content):
+        cp = FromCachedSecretsCredentialProvider()
+        cp.load_credentials()
+
+    assert cp.credentials == {
+        "refresh_token": REFRESH_TOKEN,
+        "lwa_app_id": LWA_APP_ID,
+        "lwa_client_secret": LWA_CLIENT_SECRET,
+        "aws_access_key": AWS_ACCESS_KEY,
+        "aws_secret_key": AWS_SECRET_KEY,
+        "role_arn": ROLE_ARN,
+    }


### PR DESCRIPTION
This change generalizes the implementation of `FromSecretsCredentialProvider`, to provide multiple implementations. Based on it, a new credential provider `FromCachedSecretsCredentialProvider` has been added.

The new credential provider uses the caching capabilities provided by [`aws-secretsmanager-caching-python`](https://github.com/aws/aws-secretsmanager-caching-python), to reduce the amount of calls to AWS Secrets Manager.