### PR TITLE
Encode slash character in get_listings_item

### DIFF
--- a/sp_api/base/helpers.py
+++ b/sp_api/base/helpers.py
@@ -7,7 +7,7 @@ from urllib import parse
 
 
 def fill_query_params(query, *args):
-    return query.format(*[parse.quote(arg, safe="") for arg in args])
+    return query.format(*[parse.quote(arg, safe='') for arg in args])
 
 
 def sp_endpoint(path, method='GET'):

--- a/sp_api/base/helpers.py
+++ b/sp_api/base/helpers.py
@@ -3,10 +3,11 @@ import hashlib
 import base64
 import warnings
 import functools
+from urllib import parse
 
 
 def fill_query_params(query, *args):
-    return query.format(*args)
+    return query.format(*[parse.quote(arg, safe="") for arg in args])
 
 
 def sp_endpoint(path, method='GET'):


### PR DESCRIPTION
Hi,

Thank you so much for putting effort into this wrapper as it has created so much value for us. The thing is lately I ran into an issue in `ListingsItems` in fact I need to get a list of items with the given SKU (DE-36023/4) which has special characters including slash which causes an unexpected behavior:

```
Traceback (most recent call last):
  File "/Users/daydad/Desktop/forks/python-amazon-sp-api/test.py", line 10, in <module>
    d = get_listingitems_per_sku(customer, "DE-36023/4")
  File "/Users/daydad/Desktop/forks/python-amazon-sp-api/test.py", line 5, in get_listingitems_per_sku
    return ListingsItems(credentials=customer.get_credentials()).get_listings_item(sellerId=customer.selling_partner_id, sku=sku, includedData="summaries,issues,attributes,offers").payload
  File "/Users/daydad/Desktop/forks/python-amazon-sp-api/sp_api/base/helpers.py", line 22, in wrapper
    return function(*args, **kwargs)
  File "/Users/daydad/Desktop/forks/python-amazon-sp-api/sp_api/api/listings_items/listings_items.py", line 61, in get_listings_item
    return self._request(fill_query_params(kwargs.pop('path'), sellerId, sku), params=kwargs)
  File "/Users/daydad/Desktop/forks/python-amazon-sp-api/sp_api/base/client.py", line 157, in _request
    return self._check_response(res, res_no_data, bulk, wrap_list)
  File "/Users/daydad/Desktop/forks/python-amazon-sp-api/sp_api/base/client.py", line 183, in _check_response
    raise exception(error, headers=res.headers)
sp_api.base.exceptions.SellingApiForbiddenException: [{'message': 'Access to requested resource is denied.', 'code': 'Unauthorized', 'details': ''}]

```

Code:

```
ListingsItems().get_listings_item(sellerId=seller_id, sku=sku, includedData="summaries,issues,attributes,offers")
```


In this pull request, the slash characters in SKU are quoted in order to avoid sending an invalid HTTP request to server.