### PR TITLE
Escape commas in sellerSkus

### DIFF
--- a/sp_api/api/inventories/inventories.py
+++ b/sp_api/api/inventories/inventories.py
@@ -64,7 +64,7 @@ class Inventories(Client):
             "granularityId": kwargs.get('granularityId', self.marketplace_id)
         })
         if 'sellerSkus' in kwargs:
-            kwargs.update({'sellerSkus': ','.join(kwargs.get('sellerSkus'))})
+            kwargs.update({'sellerSkus': ','.join([k.replace(',', r'\,') for k in kwargs['sellerSkus']])})
 
         return self._request(kwargs.pop('path'), params=kwargs)
 


### PR DESCRIPTION
If a SKU contains commas, Amazon will treat it as two different SKUs unless we do this.