### PR TITLE
misc: allow empty files for create_feed_document api

### DIFF
--- a/sp_api/api/feeds/feeds.py
+++ b/sp_api/api/feeds/feeds.py
@@ -156,7 +156,7 @@ class Feeds(Client):
         For more information, see "Usage Plans and Rate Limits" in the Selling Partner API documentation.
 
         Args:
-            file: File or File like object
+            file: File or File like object. Setting this to None will skip the upload.
             content_type: str
             body: | * REQUIRED {'description': 'Specifies the content type for the createFeedDocument operation.', 'properties': {'contentType': {'description': 'The content type of the feed.', 'type': 'string'}}, 'required': ['contentType'], 'type': 'object'}
 
@@ -168,6 +168,10 @@ class Feeds(Client):
             'contentType': kwargs.get('contentType', content_type)
         }
         response = self._request(kwargs.get('path'), data={**data, **kwargs})
+
+        if(file is None):
+            return response
+
         upload_data = file.read()
         try:
             upload_data = upload_data.decode('iso-8859-1')


### PR DESCRIPTION
Hi,

first of all thanks for this awesome library, it helps us a lot with our daily tasks :+1: 

Regarding the [`/feeds/2021-06-30/documents`](https://github.com/amzn/selling-partner-api-models/blob/main/models/feeds-api-model/feeds_2021-06-30.json#L949) endpoint, this library provides a very comfortable way of creating a feeds document.
However, the implementation of this endpoint in this library does more than the actual endpoint:
While the endpoints only specifies a response containing a presigned url, which can then be used to upload a file, this library enforces to provide a file.
In case you have the file, this is very convenient, but this is not always the case and does not work with the sandbox api.

So I suggest to only do the upload if a file is actually provided. By not changing the parameter set of the endpoint, this enforces users to explicitly set the `file = None` and does not break anything.

Any opinions on that approach are welcome.

Happy to hear from you @saleweaver 