### PR TITLE
Fix/get order metrics

### DIFF
--- a/sp_api/api/sales/sales.py
+++ b/sp_api/api/sales/sales.py
@@ -62,7 +62,7 @@ class Sales(Client):
         if granularityTimeZone:
             kwargs.update({'granularityTimeZone': granularityTimeZone})
         if 'sku' in kwargs:
-            kwargs.update({'sku': urllib.parse.quote_plus(kwargs.pop('sku'))})
+            kwargs.update({'sku': urllib.parse.quote(kwargs.pop('sku'), safe='')})
         return self._request(kwargs.pop('path'), params=kwargs)
 
     @staticmethod


### PR DESCRIPTION
Hi, 
thanks for the great API, it really simplifies the daily tasks with the SP-API. 

however, I was having issues getting the data from the sales endpoint get_order_metrics for SKUs that include a space (e.g. 'sku 1' ) due to the encoding.  I believe that is a similar issue mentioned here: https://github.com/saleweaver/python-amazon-sp-api/issues/890 

So I would suggest to `urllib.parse.quote('sku', safe='')` instead of `urllib.parse.quote_plus('sku')` to avoid encoding issues. This change should ensure that both `'/'` and `' '` are safe encoded and avoid breaking anything else. 

For example: 
`urllib.parse.quote_plus('/El Niño/')` yields `'%2FEl+Ni%C3%B1o%2F'`
`urllib.parse.quote('/El Niño/', safe='')` yields `'%2FEl%20Ni%C3%B1o%2F'`
Link to original documentation: https://docs.python.org/3/library/urllib.parse.html#urllib.parse.quote

Any opinions on that approach are welcome.

looking forward to hearing from you @saleweaver