### PR TITLE
Remove version upper bounds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,10 +7,10 @@ setup(
     version=__version__,
     install_requires=[
         "requests",
-        "boto3>=1.16.39,<2",
-        "cachetools>=4.2,<5.4",
+        "boto3>=1.16.39",
+        "cachetools>=4.2",
         "pytz",
-        "confuse>=1.4,<2.1"
+        "confuse>=1.4"
     ],
     extras_require={
         "aws-caching": ["aws-secretsmanager-caching"],


### PR DESCRIPTION
Upper version bounds are generally a nuisance, as they unnecessarily block upgrades. See this post for a summary and then a long discussion: https://iscinumpy.dev/post/bound-version-constraints/

I noticed you have upper version bounds, then you spend a lot of time updating them as in eb7be07, 8ae01c8 , 2c90d24, 73ceb7c. (And if you don't release these updates, you block users from upgrading themselves, which could block important security fixes!)

This PR removes the upper version bounds. You can remove all that busywork and help users out. In the rare case a new version of a dep causes problems, users should be pinning, and you can release a fix.