### PR TITLE
Update doc and test for Prepinstructions to indicate the required asin or sellersku list needs to be comma separated string

### DIFF
--- a/sp_api/api/fulfillment_inbound/fulfillment_inbound.py
+++ b/sp_api/api/fulfillment_inbound/fulfillment_inbound.py
@@ -218,7 +218,8 @@ class FulfillmentInbound(Client):
         Examples:
             literal blocks::
 
-                FulfillmentInbound().prep_instruction({"ShipToCountryCode": "US", "ASINList": ["ASIN1"]})
+                FulfillmentInbound().prep_instruction({"ShipToCountryCode": "US", "ASINList": "ASIN1,ASIN2,ASIN3"})
+                FulfillmentInbound().prep_instruction({"ShipToCountryCode": "US", "SellerSKUList": "SellerSKU1,SellerSKU2,SellerSKU3"})
 
         Args:
             data:

--- a/tests/api/fulfillment_inbound/test_fulfillment_inbound.py
+++ b/tests/api/fulfillment_inbound/test_fulfillment_inbound.py
@@ -125,8 +125,8 @@ def test_preorder():
 #     assert res.errors is None
 
 
-def test_get_prep_orders():
-    res = FulfillmentInbound().prep_instruction({"ShipToCountryCode": "US", "ASINList": ["ASIN1"]})
+def test_prep_instruction():
+    res = FulfillmentInbound().prep_instruction({"ShipToCountryCode": "US", "ASINList": "ASIN1,ASIN2"})
     assert res.errors is None
 
 


### PR DESCRIPTION
Update doc and test for Prepinstructions to indicate the required asin or sellersku list needs to be comma separated string. I tested this and it works when I input a comma separated list of ASIN or SellerSKU, even though [Amazon selling partner API doc](https://developer-docs.amazon.com/sp-api/docs/fulfillment-inbound-api-v0-reference#getprepinstructions) says the parameter should be array of string.