### PR TITLE
change QueryType from DATE_RANGE to NEXT_TOKEN when loading following pages using next_tokens

### DIFF
--- a/sp_api/util/load_all_pages.py
+++ b/sp_api/util/load_all_pages.py
@@ -36,6 +36,8 @@ def load_all_pages(throttle_by_seconds: float = 2, next_token_param='NextToken',
                     if sleep_time > 0:
                         time.sleep(sleep_time)
                     kwargs.update({next_token_param: res.next_token})
+                    if kwargs['QueryType'] == 'DATE_RANGE':
+                        kwargs['QueryType'] = 'NEXT_TOKEN'                    
                 else:
                     done = True
 


### PR DESCRIPTION
The operation will load following pages using DATE_RANGE QueryType when started with QueryType DATE_RANGE, thus repeat infinitely, unless the QueryType is updated to NEXT_TOKEN during following pages retrieval.