### PR TITLE
remove 'aws_access_key' and 'aws_secret_key' from required credentials

### DIFF
--- a/sp_api/base/credential_provider.py
+++ b/sp_api/base/credential_provider.py
@@ -17,8 +17,6 @@ except ImportError:
 
 
 required_credentials = [
-    'aws_access_key',
-    'aws_secret_key',
     'lwa_app_id',
     'lwa_client_secret'
 ]


### PR DESCRIPTION
Hi again,

... and again thanks for this awesome library :-D

I want to discuss the `required_credentials` in the [credential_provider](https://github.com/saleweaver/python-amazon-sp-api/blob/master/sp_api/base/credential_provider.py#L19).

It forces providing an 'aws_access_key' and a 'aws_secret_key'.

However, the default behavior of boto is to use the environment. This is especially handy if you run it it a lambda or ecs task definition, where you already attached a role to lambda / task.
In these cases, the environment has (short-living) session credentials which are then picked up by the underlying boto library.

Therefore, you usually want to omit the credential fields in the library.

Sadly, most tutorials from AWS and the internet always provide credentials, which gives the impression that it is mandatory, but it is not.

I already tested it successfully today on my branch.

Let me know what you think @saleweaver and how I can support you for this to be merged.

Kind regards