### PR TITLE
Added Products/v0/getListingOffersBatch endpoint. Fixes #1067

### DIFF
--- a/sp_api/api/products/products.py
+++ b/sp_api/api/products/products.py
@@ -1,7 +1,7 @@
 from typing import Optional, List, Dict, Union
 
 from sp_api.base import ApiResponse, Client, fill_query_params, sp_endpoint
-from sp_api.api.products.products_definitions import GetItemOffersBatchRequest, ItemOffersRequest
+from sp_api.api.products.products_definitions import GetItemOffersBatchRequest, GetListingOffersBatchRequest
 
 
 class Products(Client):
@@ -234,6 +234,36 @@ class Products(Client):
             get_item_offers_batch_request = {"requests": requests_}
 
         return self._request(kwargs.pop('path'), data=get_item_offers_batch_request, params={**kwargs},
+                             add_marketplace=False)
+
+    @sp_endpoint('/batches/products/pricing/v0/listingOffers', method='POST')
+    def get_listing_offers_batch(self, requests_: Optional[Union[List[Dict], GetListingOffersBatchRequest]] = None, **kwargs) -> ApiResponse:
+        """
+        get_listing_offers_batch(self, requests_: Optional[Union[List[Dict], GetListingOffersBatchRequest]], **kwargs) -> ApiResponse
+        Returns the lowest priced offers for a batch of listings based on ASIN.
+
+        **Usage Plan:**
+
+        ======================================  ==============
+        Rate (requests per second)               Burst
+        ======================================  ==============
+        .5                                       1
+        ======================================  ==============
+
+        Args:
+            requests_: Optional (Body) [dict] The request associated with the getListingOffersBatch API call.
+
+
+        Returns:
+            ApiResponse
+
+        """
+        if isinstance(requests_, GetListingOffersBatchRequest):
+            get_listing_offers_batch_request = requests_.to_dict()
+        else:
+            get_listing_offers_batch_request = {"requests": requests_}
+
+        return self._request(kwargs.pop('path'), data=get_listing_offers_batch_request, params={**kwargs},
                              add_marketplace=False)
 
     def _create_get_pricing_request(self, item_list, item_type, **kwargs):

--- a/sp_api/api/products/products_definitions.py
+++ b/sp_api/api/products/products_definitions.py
@@ -40,4 +40,43 @@ class GetItemOffersBatchRequest:
             parsed_requestes.append(request)
 
         return parsed_requestes
+    
+
+@dataclass
+class ListingOffersRequest:
+    """ Implements definition: https://developer-docs.amazon.com/sp-api/docs/product-pricing-api-v0-reference
+    #listingoffersrequest """
+    uri: str
+    MarketplaceId: str
+    ItemCondition: str
+    method: str = "GET"
+    CustomerType: str = "Consumer"
+
+
+@dataclass
+class GetListingOffersBatchRequest:
+    """ Implements definition: https://developer-docs.amazon.com/sp-api/docs/product-pricing-api-v0-reference
+    #getlistingoffersbatchrequest """
+    requests: Optional[List[Union[ListingOffersRequest, Dict]]] = None
+
+    def __post_init__(self):
+        self.requests = self.parse_requests(self.requests)
+
+    def to_dict(self):
+        return asdict(self)
+
+    @staticmethod
+    def parse_requests(requests) -> List[ListingOffersRequest]:
+        parsed_requestes = []
+
+        for request in requests:
+            if isinstance(request, Dict):
+                request = ListingOffersRequest(**request)
+
+            if not isinstance(request, ListingOffersRequest):
+                raise TypeError
+
+            parsed_requestes.append(request)
+
+        return parsed_requestes
 

--- a/tests/api/products/test_products.py
+++ b/tests/api/products/test_products.py
@@ -1,4 +1,7 @@
+import traceback
+
 from sp_api.api.products.products import Products
+from sp_api.api.products.products_definitions import GetListingOffersBatchRequest, ListingOffersRequest
 from sp_api.base import ApiResponse, Marketplaces, SellingApiBadRequestException
 
 
@@ -30,7 +33,111 @@ def test_competitive_pricing_for_asin():
 
 
 def test_get_item_offers_batch():
-    res = Products().get_item_offers_batch([])
+    res = Products().get_item_offers_batch(requests_=[
+        {
+            "uri": "/products/pricing/v0/items/B000P6Q7MY/offers",
+            "method": "GET",
+            "MarketplaceId": "ATVPDKIKX0DER",
+            "ItemCondition": "New",
+            "CustomerType": "Consumer"
+        },
+        {
+            "uri": "/products/pricing/v0/items/B001Q3KU9Q/offers",
+            "method": "GET",
+            "MarketplaceId": "ATVPDKIKX0DER",
+            "ItemCondition": "New",
+            "CustomerType": "Consumer"
+        },
+        {
+            "uri": "/products/pricing/v0/items/B007Z07UK6/offers",
+            "method": "GET",
+            "MarketplaceId": "ATVPDKIKX0DER",
+            "ItemCondition": "New",
+            "CustomerType": "Consumer"
+        },
+        {
+            "uri": "/products/pricing/v0/items/B000OQA3N4/offers",
+            "method": "GET",
+            "MarketplaceId": "ATVPDKIKX0DER",
+            "ItemCondition": "New",
+            "CustomerType": "Consumer"
+        },
+        {
+            "uri": "/products/pricing/v0/items/B07PTMKYS7/offers",
+            "method": "GET",
+            "MarketplaceId": "ATVPDKIKX0DER",
+            "ItemCondition": "New",
+            "CustomerType": "Consumer"
+        },
+        {
+            "uri": "/products/pricing/v0/items/B001PYUTII/offers",
+            "method": "GET",
+            "MarketplaceId": "ATVPDKIKX0DER",
+            "ItemCondition": "New",
+            "CustomerType": "Consumer"
+        },
+        {
+            "uri": "/products/pricing/v0/items/B00505DW2I/offers",
+            "method": "GET",
+            "MarketplaceId": "ATVPDKIKX0DER",
+            "ItemCondition": "New",
+            "CustomerType": "Consumer"
+        },
+        {
+            "uri": "/products/pricing/v0/items/B00CGZQU42/offers",
+            "method": "GET",
+            "MarketplaceId": "ATVPDKIKX0DER",
+            "ItemCondition": "New",
+            "CustomerType": "Consumer"
+        },
+        {
+            "uri": "/products/pricing/v0/items/B01LY2ZYRF/offers",
+            "method": "GET",
+            "MarketplaceId": "ATVPDKIKX0DER",
+            "ItemCondition": "New",
+            "CustomerType": "Consumer"
+        },
+        {
+            "uri": "/products/pricing/v0/items/B00KFRNZY6/offers",
+            "method": "GET",
+            "MarketplaceId": "ATVPDKIKX0DER",
+            "ItemCondition": "New",
+            "CustomerType": "Consumer"
+        }
+    ])
     assert res.errors is None
     assert isinstance(res, ApiResponse)
 
+def test_get_listing_offers_batch():
+    reqs = [
+        ListingOffersRequest(
+            uri="/products/pricing/v0/listings/GC-QTMS-SV2I/offers",
+            MarketplaceId='ATVPDKIKX0DER',
+            ItemCondition='New'
+        ),
+        ListingOffersRequest(
+            uri="/products/pricing/v0/listings/VT-DEIT-57TQ/offers",
+            MarketplaceId='ATVPDKIKX0DER',
+            ItemCondition='New'
+        ),
+        ListingOffersRequest(
+            uri="/products/pricing/v0/listings/NA-H7X1-JYTM/offers",
+            MarketplaceId='ATVPDKIKX0DER',
+            ItemCondition='New'
+        ),
+        ListingOffersRequest(
+            uri="/products/pricing/v0/listings/RL-JVOC-MBSL/offers",
+            MarketplaceId='ATVPDKIKX0DER',
+            ItemCondition='New'
+        ),
+        ListingOffersRequest(
+            uri="/products/pricing/v0/listings/74-64KG-H9W9/offers",
+            MarketplaceId='ATVPDKIKX0DER',
+            ItemCondition='New'
+        ),
+    ]
+
+    batch_req = GetListingOffersBatchRequest(reqs)
+    res = Products().get_listing_offers_batch(batch_req)
+    assert res.errors is None
+    assert isinstance(res, ApiResponse)


### PR DESCRIPTION
This pull request implements the [Products_v0_getListingOffersBatch](https://developer-docs.amazon.com/sp-api/docs/product-pricing-api-v0-reference#getlistingoffersbatch) endpoint, mirroring the code style of [Products_v0_getItemOffersBatch](https://developer-docs.amazon.com/sp-api/docs/product-pricing-api-v0-reference#getitemoffersbatch).


#### Additional notes:
- Added test using sandbox test values to verify new endpoint. 
- Corrected preexisting failing GetItemOffersBatch test using sandbox test values, allowing all existing "Products" client tests to pass.