### PR TITLE
Fix regression in `catalog_items`

### DIFF
--- a/sp_api/api/catalog_items/catalog_items.py
+++ b/sp_api/api/catalog_items/catalog_items.py
@@ -56,8 +56,9 @@ class CatalogItems(Client):
             ApiResponse:
         """
 
-        if isinstance(kwargs['includedData'], list):
-            kwargs['includedData'] = ",".join(kwargs['includedData'])
+        includedData = kwargs.get('includedData', [])
+        if includedData and isinstance(includedData, list):
+            kwargs['includedData'] = ','.join(includedData)
         return self._request(kwargs.pop('path'),  params=kwargs)
 
     @sp_endpoint('/catalog/<version>/items/{}', method='GET')
@@ -86,6 +87,7 @@ class CatalogItems(Client):
             ApiResponse:
         """
 
-        if isinstance(kwargs['includedData'], list):
-            kwargs['includedData'] = ",".join(kwargs['includedData'])
+        includedData = kwargs.get('includedData', [])
+        if includedData and isinstance(includedData, list):
+            kwargs['includedData'] = ','.join(includedData)
         return self._request(fill_query_params(kwargs.pop('path'), asin), params=kwargs)

--- a/tests/api/catalog_items/test_catalog_items.py
+++ b/tests/api/catalog_items/test_catalog_items.py
@@ -7,6 +7,10 @@ def test_get_catalog_item():
     assert res.errors is None
     assert isinstance(res, ApiResponse)
 
+    # No `includedData` parameter provided - Amazon should default to
+    # "summaries".
+    assert 'summaries' in res.payload
+
 
 def test_get_catalog_item_version():
     res = Catalog(version=CatalogItemsVersion.LATEST).get_catalog_item('B098RX87V2')
@@ -17,6 +21,11 @@ def test_get_catalog_item_version():
 def test_list_catalog_items():
     res = Catalog().search_catalog_items(keywords='test')
     assert res.errors is None
+
+    # No `includedData` parameter provided - Amazon should default to
+    # "summaries" for every returned item.
+    for item in res.items:
+        assert 'summaries' in item
 
 
 def test_get_catalog_item_foo():


### PR DESCRIPTION
Fix the `search_catalog_items` and `get_catalog_item` API calls where instead of letting the request flow to Amazon when no `includedData` param is provided, it raises a `KeyError`.

I think this change also addressese [this](https://github.com/saleweaver/python-amazon-sp-api/discussions/1131) discussion.