### PR TITLE
Fix product fees estimate not being able to retry requests

### DIFF
--- a/sp_api/api/product_fees/product_fees.py
+++ b/sp_api/api/product_fees/product_fees.py
@@ -135,7 +135,7 @@ class ProductFees(Client):
         return self._request('/products/fees/v0/feesEstimate', data=data, params=dict(method='POST'), wrap_list=True)
 
 
-    def _create_body(self, price, shipping_price=None, currency='USD', is_fba=False, identifier=None,points: dict = None,
+    def _create_body(self, price, shipping_price=None, currency='USD', is_fba=False, identifier=None, points: dict = None,
                      marketplace_id: str = None, optional_fulfillment_program: str=None, id_type=None, id_value=None):
         """
         Create request body

--- a/sp_api/api/product_fees/product_fees.py
+++ b/sp_api/api/product_fees/product_fees.py
@@ -128,8 +128,6 @@ class ProductFees(Client):
         """
         data = [
             dict(
-                IdType = er.pop('id_type'),
-                IdValue = er.pop('id_value'),
                 **self._create_body(**er)
             )
             for er in estimate_requests
@@ -137,7 +135,7 @@ class ProductFees(Client):
         return self._request('/products/fees/v0/feesEstimate', data=data, params=dict(method='POST'), wrap_list=True)
 
 
-    def _create_body(self, price, shipping_price=None, currency='USD', is_fba=False, identifier=None,
+    def _create_body(self, price, id_type, id_value, shipping_price=None, currency='USD', is_fba=False, identifier=None,
                      points: dict = None, marketplace_id: str = None, optional_fulfillment_program: str=None):
         """
         Create request body
@@ -154,6 +152,8 @@ class ProductFees(Client):
 
         """
         return {
+            "IdType": id_type,
+            "IdValue" : id_value,
             'FeesEstimateRequest': {
                 'Identifier': identifier or str(price),
                 'PriceToEstimateFees': {

--- a/sp_api/api/product_fees/product_fees.py
+++ b/sp_api/api/product_fees/product_fees.py
@@ -135,7 +135,7 @@ class ProductFees(Client):
         return self._request('/products/fees/v0/feesEstimate', data=data, params=dict(method='POST'), wrap_list=True)
 
 
-    def _create_body(self, price, id_type, id_value, shipping_price=None, currency='USD', is_fba=False, identifier=None,
+    def _create_body(self, price, id_type=None, id_value=None, shipping_price=None, currency='USD', is_fba=False, identifier=None,
                      points: dict = None, marketplace_id: str = None, optional_fulfillment_program: str=None):
         """
         Create request body
@@ -151,9 +151,7 @@ class ProductFees(Client):
         Returns:
 
         """
-        return {
-            "IdType": id_type,
-            "IdValue" : id_value,
+        body = {
             'FeesEstimateRequest': {
                 'Identifier': identifier or str(price),
                 'PriceToEstimateFees': {
@@ -172,6 +170,12 @@ class ProductFees(Client):
                 'MarketplaceId': marketplace_id or self.marketplace_id
             }
         }
+        
+        if id_type and id_value:
+            body["IdType"] = id_type
+            body["IdValue"] = id_value
+
+        return body
 
 
     def _add_marketplaces(self, data):

--- a/sp_api/api/product_fees/product_fees.py
+++ b/sp_api/api/product_fees/product_fees.py
@@ -135,8 +135,8 @@ class ProductFees(Client):
         return self._request('/products/fees/v0/feesEstimate', data=data, params=dict(method='POST'), wrap_list=True)
 
 
-    def _create_body(self, price, id_type=None, id_value=None, shipping_price=None, currency='USD', is_fba=False, identifier=None,
-                     points: dict = None, marketplace_id: str = None, optional_fulfillment_program: str=None):
+    def _create_body(self, price, shipping_price=None, currency='USD', is_fba=False, identifier=None,points: dict = None,
+                     marketplace_id: str = None, optional_fulfillment_program: str=None, id_type=None, id_value=None):
         """
         Create request body
 
@@ -170,7 +170,7 @@ class ProductFees(Client):
                 'MarketplaceId': marketplace_id or self.marketplace_id
             }
         }
-        
+
         if id_type and id_value:
             body["IdType"] = id_type
             body["IdValue"] = id_value


### PR DESCRIPTION
Previously when calling `get_product_fees_estimate` after a `SellingApiRequestThrottledException` with the `throttle_retry` decorator, an error would occur because the request object had data removed.

To fix I removed the removal of the values from the object and passed them down into the `_create_body` function instead