### PR TITLE
Fixed datetime format issue for getOrderMetrics API call

### DIFF
--- a/sp_api/api/sales/sales.py
+++ b/sp_api/api/sales/sales.py
@@ -79,4 +79,4 @@ class Sales(Client):
         if isinstance(datetime_obj, str):
             return datetime_obj
         fmt = '%Y-%m-%dT%H:%M:%S%z'
-        return datetime_obj.strftime(fmt)[:-2] + ':00'
+        return datetime_obj.astimezone().isoformat(timespec="seconds")


### PR DESCRIPTION
Fixes:
https://github.com/saleweaver/python-amazon-sp-api/issues/1119