### PR TITLE
Prevent hardcoded redirect to https://sp-api-docs.saleweaver.com/

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ orders = Orders().get_orders(
 
 ### Documentation
 
-Documentation is available [here](https://sp-api-docs.saleweaver.com/?utm_source=github&utm_medium=repo&utm_term=text)
+Documentation is available [here](https://python-amazon-sp-api.readthedocs.io/en/latest/index.html)
 
-[![Documentation Status](https://img.shields.io/readthedocs/python-amazon-sp-api?style=for-the-badge)](https://sp-api-docs.saleweaver.com/?utm_source=github&utm_medium=repo&utm_term=badge)
+[![Documentation Status](https://img.shields.io/readthedocs/python-amazon-sp-api?style=for-the-badge)](https://python-amazon-sp-api.readthedocs.io/en/latest/index.html)
 
 ### Consultation
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,25 @@
-.. meta::
-   :http-equiv=Refresh: 0; url='https://sp-api-docs.saleweaver.com/'
+.. PYTHON-AMAZON-SP-API documentation master file, created by
+   sphinx-quickstart on Thu Jan 28 17:29:02 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+Welcome to PYTHON-AMAZON-SP-API's documentation!
+================================================
 
-The documentation has moved. Please visit `the new site`_
+.. toctree::
+   :maxdepth: 2
 
-.. _the new site: https://sp-api-docs.saleweaver.com
+   installation
+   credentials
+   client_usage
+   endpoints
+   responses
+   exceptions
+   utils
+   testing
 
+
+Indices and tables
+==================
+*  :ref:`genindex`
+*  :ref:`modindex`
+*  :ref:`search`


### PR DESCRIPTION
The current docs file `index.rst` redirects to `https://sp-api-docs.saleweaver.com/` on load. This PR removes the redirect and updates the readme links to the readthedocs.io domain. This should resolve issues #1185 and #1190