### PR TITLE
Fix create_feed_document upload encoding

### DIFF
--- a/sp_api/api/feeds/feeds.py
+++ b/sp_api/api/feeds/feeds.py
@@ -174,7 +174,7 @@ class Feeds(Client):
 
         upload_data = file.read()
         try:
-            upload_data = upload_data.decode('iso-8859-1')
+            upload_data = upload_data.encode('iso-8859-1')
         except AttributeError:
             pass
         upload = requests.put(


### PR DESCRIPTION
Hi,

I had trouble uploading `POST_FLAT_FILE_LISTINGS_DATA` Feeds with the `create_feed_document` method to the Amazon Germany marketplace that contained special German characters (ä,ö,ü,ß). The encoding of the characters that arrived at Amazon seemed wrong, even though the ISO-8859-1 encoding should be correct. I'm not 100% sure if my code change is correct in all cases, but it did the trick for me.  
Decoding in that place seems wrong to me, because it converts already encoded upload data back to `str`, which is then uploaded with the default encoding of requests which I think is UTF-8, which Amazon cannot handle.

Thanks for the great library!