### PR TITLE
add support for search_listings_items

### DIFF
--- a/sp_api/api/listings_items/listings_items.py
+++ b/sp_api/api/listings_items/listings_items.py
@@ -63,6 +63,32 @@ For more information, see the [Listings Items API Use Case Guide](https://github
 
         return self._request(fill_query_params(kwargs.pop('path'), sellerId, sku), params=kwargs)
 
+    @sp_endpoint('/listings/2021-08-01/items/{}', method='GET')
+    def search_listings_items(self, sellerId, **kwargs) -> ApiResponse:
+        """
+        search_listings_items(self, sellerId, **kwargs) -> ApiResponse
+        Search for and return list of listings items and respective details for a selling partner.
+        **Usage Plan:**
+        ======================================  ==============
+        Rate (requests per second)               Burst
+        ======================================  ==============
+        5                                       5
+        ======================================  ==============
+        The `x-amzn-RateLimit-Limit` response header returns the usage plan rate limits that were applied to the requested operation, when available. The table above indicates the default rate and burst values for this operation. Selling partners whose business demands require higher throughput may see higher rate and burst values then those shown here. For more information, see [Usage Plans and Rate Limits in the Selling Partner API](https://github.com/amzn/selling-partner-api-docs/blob/main/guides/en-US/usage-plans-rate-limits/Usage-Plans-and-Rate-Limits.md).
+        Args:
+            sellerId:string | * REQUIRED A selling partner identifier, such as a merchant account or vendor code
+            key marketplaceIds:array | * REQUIRED A comma-delimited list of Amazon marketplace identifiers for the request.
+            key issueLocale:string |  A locale for localization of issues. When not provided, the default language code of the first marketplace is used. Examples: "en_US", "fr_CA", "fr_FR". Localized messages default to "en_US" when a localization is not available in the specified locale.
+            key includedData:array |  A comma-delimited list of data sets to include in the response. Default: summaries.
+        Returns:
+            ApiResponse:
+        """
+        if kwargs.get('includedData') and isinstance(kwargs.get('includedData'), abc.Iterable) and not isinstance(kwargs.get('includedData'), str):
+            kwargs['includedData'] = ','.join(
+                [x.value if isinstance(x, IncludedData) else x for x in kwargs['includedData']])
+
+        return self._request(fill_query_params(kwargs.pop('path'), sellerId), params=kwargs)
+
     @sp_endpoint('/listings/2021-08-01/items/{}/{}', method='PATCH')
     def patch_listings_item(self, sellerId, sku, **kwargs) -> ApiResponse:
         """

--- a/tests/api/listings_items/test_listings_items.py
+++ b/tests/api/listings_items/test_listings_items.py
@@ -6,6 +6,10 @@ def test_get_listings_item():
     res = ListingsItems().get_listings_item('xxx', 'xxx')
     assert res is not None
 
+def test_search_listings_items():
+    res = ListingsItems().search_listings_items('xxx')
+    assert res is not None
+
 
 def test_put_listings_item():
     res = ListingsItems().put_listings_item('xxx', 'xxx', body={


### PR DESCRIPTION
## Summary by Sourcery

Add support for searching listings items by implementing the `search_listings_items` method in the ListingsItems API and include a corresponding test case.

New Features:
- Introduce a new method `search_listings_items` to search and retrieve listings items and their details for a selling partner.

Tests:
- Add a test case for the new `search_listings_items` method to ensure it returns a non-null response.