### PR TITLE
fix: correct ExternalFulfillment import path

### DIFF
--- a/sp_api/api/__init__.py
+++ b/sp_api/api/__init__.py
@@ -97,7 +97,7 @@ from .amazon_warehousing_and_distribu.amazon_warehousing_and_distribu import (
     AmazonWarehousingAndDistributionVersion,
 )
 
-from .external_fulfillment import ExternalFulfillment
+from .external_fulfillment.external_fulfillment import ExternalFulfillment
 
 __all__ = [
     "Sales",


### PR DESCRIPTION
Fixed import path for ExternalFulfillment to use the full module path instead of package-level import.

https://github.com/saleweaver/python-amazon-sp-api/issues/1868

## Summary by Sourcery

Bug Fixes:
- Correct ExternalFulfillment import to use the module-level path in sp_api/api/__init__.py