### PR TITLE
Prevent AttributeError when values are None

### DIFF
--- a/sp_api/base/ApiResponse.py
+++ b/sp_api/base/ApiResponse.py
@@ -44,13 +44,13 @@ class ApiResponse:
         self.errors = errors
         self.pagination = pagination
         self.headers = headers
-        self.rate_limit = headers.get("x-amzn-RateLimit-Limit")
+        self.rate_limit = (headers or {}).get("x-amzn-RateLimit-Limit")
         try:
             self.next_token = (
                 nextToken
                 or self.payload.get("pagination", {}).get("nextToken", None)
                 or self.payload.get("NextToken", None)
-                or self.pagination.get("nextToken", None)
+                or (self.pagination or {}).get("nextToken", None)
                 or self.payload.get("nextPageToken", None)
                 or self.payload.get("nextToken", None)
             )


### PR DESCRIPTION
- Fixed `ApiResponse` init to avoid calling `.get()` on `pagination=None`, so it no longer triggers the silenced `AttributeError` and can still fall through to payload keys `nextPageToken` and `nextToken`, which were previously ignored as a result of this error.
- Also made headers access safe in init by using (headers or {}).

## Summary by Sourcery

Handle optional pagination and headers safely in ApiResponse initialization to prevent AttributeError when values are None.

Bug Fixes:
- Avoid calling .get() on a None pagination object when resolving next_token.
- Avoid calling .get() on None headers when resolving rate_limit.