### PR TITLE
Add Orders API 2026-01-01 client

### DIFF
--- a/sp_api/api/__init__.py
+++ b/sp_api/api/__init__.py
@@ -1,6 +1,7 @@
 from .finances.finances import Finances, FinancesVersion
 from .notifications.notifications import Notifications
-from .orders.orders import Orders, OrdersV20260101
+from .orders.orders import Orders, OrdersVersion
+from .orders.orders_2026_01_01 import OrdersV20260101
 from .product_fees.product_fees import ProductFees
 from .sellers.sellers import Sellers
 from .reports.reports import Reports
@@ -104,6 +105,7 @@ __all__ = [
     "Products",
     "Reports",
     "Orders",
+    "OrdersVersion",
     "OrdersV20260101",
     "Sellers",
     "Notifications",

--- a/sp_api/api/orders/orders.py
+++ b/sp_api/api/orders/orders.py
@@ -1,12 +1,60 @@
-from sp_api.base import sp_endpoint, fill_query_params, ApiResponse, deprecated
-from sp_api.base import Client, Marketplaces
+from __future__ import annotations
+
+import enum
+from typing import Any, Literal, overload
+
+from sp_api.base import ApiResponse, Client, Marketplaces, deprecated, fill_query_params, sp_endpoint
 from sp_api.util import normalize_csv_param
+
+from .orders_2026_01_01 import OrdersV20260101
+
+
+class OrdersVersion(str, enum.Enum):
+    V0 = "v0"  # legacy
+    V_2026_01_01 = "2026-01-01"
+    LATEST = "2026-01-01"
 
 
 class Orders(Client):
-    """
+    """Orders API client.
+
+    This class implements the legacy Orders API **v0**.
+
+    If you pass version "2026-01-01" (or :class:`OrdersVersion.V_2026_01_01`)
+    to the constructor, :meth:`__new__` returns an instance of
+    :class:`~sp_api.api.orders.orders_2026_01_01.OrdersV20260101` instead.
+
     :link: https://github.com/amzn/selling-partner-api-docs/tree/main/references/orders-api
     """
+
+    @overload
+    def __new__(
+        cls,
+        *args: Any,
+        version: Literal[OrdersVersion.V_2026_01_01, "2026-01-01"],
+        **kwargs: Any,
+    ) -> OrdersV20260101: ...
+
+    @overload
+    def __new__(
+        cls,
+        *args: Any,
+        version: str | OrdersVersion | None = None,
+        **kwargs: Any,
+    ) -> "Orders": ...
+
+    def __new__(
+        cls,
+        *args: Any,
+        version: str | OrdersVersion | None = None,
+        **kwargs: Any,
+    ):
+        if cls is Orders:
+            v = version if version is not None else kwargs.get("version")
+            if v in (OrdersVersion.V_2026_01_01, OrdersVersion.LATEST, "2026-01-01"):
+                kwargs.pop("version", None)
+                return OrdersV20260101(*args, **kwargs)
+        return super().__new__(cls)
 
     @sp_endpoint("/orders/v0/orders")
     def get_orders(self, **kwargs) -> ApiResponse:
@@ -361,55 +409,3 @@ class Orders(Client):
             self.restricted_data_token = None
         return r
 
-
-class OrdersV20260101(Client):
-    """Orders API (version 2026-01-01).
-
-    This is a newer Orders API version that uses different endpoints/parameters
-    than the legacy v0 Orders API implemented by :class:`~sp_api.api.orders.orders.Orders`.
-
-    Model source:
-    https://github.com/amzn/selling-partner-api-models/blob/main/models/orders-api-model/orders_2026-01-01.json
-    """
-
-    @sp_endpoint("/orders/2026-01-01/orders")
-    def search_orders(self, **kwargs) -> ApiResponse:
-        """Search orders.
-
-        Corresponds to GET /orders/2026-01-01/orders (operationId: searchOrders).
-
-        Common query params (see the Amazon model for the full list):
-            createdAfter, createdBefore, lastUpdatedAfter, lastUpdatedBefore,
-            fulfillmentStatuses, marketplaceIds, fulfilledBy,
-            maxResultsPerPage, paginationToken, includedData.
-
-        Notes:
-        - Parameters are lowerCamelCase in this version (e.g. createdAfter).
-        - List parameters can be passed as Python lists; they will be normalized
-          into a comma-delimited string.
-        """
-
-        normalize_csv_param(kwargs, "fulfillmentStatuses")
-        normalize_csv_param(kwargs, "marketplaceIds")
-        normalize_csv_param(kwargs, "fulfilledBy")
-        normalize_csv_param(kwargs, "includedData")
-
-        return self._request(kwargs.pop("path"), params={**kwargs})
-
-    @sp_endpoint("/orders/2026-01-01/orders/{}")
-    def get_order(self, order_id: str, **kwargs) -> ApiResponse:
-        """Get order by orderId.
-
-        Corresponds to GET /orders/2026-01-01/orders/{orderId} (operationId: getOrder).
-
-        Args:
-            order_id: The Amazon order identifier.
-            includedData: Optional list of datasets to include in the response.
-        """
-
-        normalize_csv_param(kwargs, "includedData")
-        return self._request(
-            fill_query_params(kwargs.pop("path"), order_id),
-            params={**kwargs},
-            add_marketplace=False,
-        )

--- a/sp_api/api/orders/orders_2026_01_01.py
+++ b/sp_api/api/orders/orders_2026_01_01.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sp_api.base import ApiResponse, Client, fill_query_params, sp_endpoint
+from sp_api.util import normalize_csv_param
+
+
+class OrdersV20260101(Client):
+    """Orders API (version 2026-01-01).
+
+    This is a newer Orders API version that uses different endpoints/parameters
+    than the legacy v0 Orders API implemented by :class:`sp_api.api.orders.orders.Orders`.
+
+    Model source:
+    https://github.com/amzn/selling-partner-api-models/blob/main/models/orders-api-model/orders_2026-01-01.json
+    """
+
+    @sp_endpoint("/orders/2026-01-01/orders")
+    def search_orders(self, **kwargs: Any) -> ApiResponse:
+        """Search orders.
+
+        Corresponds to GET /orders/2026-01-01/orders (operationId: searchOrders).
+
+        Notes:
+        - Parameters are lowerCamelCase in this version (e.g. createdAfter).
+        - List parameters can be passed as Python lists; they will be normalized
+          into a comma-delimited string.
+        """
+
+        normalize_csv_param(kwargs, "fulfillmentStatuses")
+        normalize_csv_param(kwargs, "marketplaceIds")
+        normalize_csv_param(kwargs, "fulfilledBy")
+        normalize_csv_param(kwargs, "includedData")
+
+        return self._request(kwargs.pop("path"), params={**kwargs})
+
+    @sp_endpoint("/orders/2026-01-01/orders/{}")
+    def get_order(self, order_id: str, **kwargs: Any) -> ApiResponse:
+        """Get order by orderId.
+
+        Corresponds to GET /orders/2026-01-01/orders/{orderId} (operationId: getOrder).
+
+        Args:
+            order_id: The Amazon order identifier.
+            includedData: Optional list of datasets to include in the response.
+        """
+
+        normalize_csv_param(kwargs, "includedData")
+        return self._request(
+            fill_query_params(kwargs.pop("path"), order_id),
+            params={**kwargs},
+            add_marketplace=False,
+        )

--- a/sp_api/asyncio/api/__init__.py
+++ b/sp_api/asyncio/api/__init__.py
@@ -1,6 +1,7 @@
 from .finances.finances import Finances, FinancesVersion
 from .notifications.notifications import Notifications
-from .orders.orders import Orders, OrdersV20260101
+from .orders.orders import Orders, OrdersVersion
+from .orders.orders_2026_01_01 import OrdersV20260101
 from .product_fees.product_fees import ProductFees
 from .sellers.sellers import Sellers
 from .reports.reports import Reports
@@ -104,6 +105,7 @@ __all__ = [
     "Products",
     "Reports",
     "Orders",
+    "OrdersVersion",
     "OrdersV20260101",
     "Sellers",
     "Notifications",

--- a/sp_api/asyncio/api/orders/orders_2026_01_01.py
+++ b/sp_api/asyncio/api/orders/orders_2026_01_01.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sp_api.asyncio.base import AsyncBaseClient
+from sp_api.base import ApiResponse, fill_query_params, sp_endpoint
+from sp_api.util import normalize_csv_param
+
+
+class OrdersV20260101(AsyncBaseClient):
+    """Orders API (version 2026-01-01) - async client.
+
+    This is a newer Orders API version that uses different endpoints/parameters
+    than the legacy v0 Orders API implemented by :class:`sp_api.asyncio.api.orders.orders.Orders`.
+
+    Model source:
+    https://github.com/amzn/selling-partner-api-models/blob/main/models/orders-api-model/orders_2026-01-01.json
+    """
+
+    @sp_endpoint("/orders/2026-01-01/orders")
+    async def search_orders(self, **kwargs: Any) -> ApiResponse:
+        """Search orders (async)."""
+
+        normalize_csv_param(kwargs, "fulfillmentStatuses")
+        normalize_csv_param(kwargs, "marketplaceIds")
+        normalize_csv_param(kwargs, "fulfilledBy")
+        normalize_csv_param(kwargs, "includedData")
+
+        return await self._request(kwargs.pop("path"), params={**kwargs})
+
+    @sp_endpoint("/orders/2026-01-01/orders/{}")
+    async def get_order(self, order_id: str, **kwargs: Any) -> ApiResponse:
+        """Get order by orderId (async)."""
+
+        normalize_csv_param(kwargs, "includedData")
+        return await self._request(
+            fill_query_params(kwargs.pop("path"), order_id),
+            params={**kwargs},
+            add_marketplace=False,
+        )


### PR DESCRIPTION
Adds support for the newly released Orders API version **2026-01-01** (sync + asyncio) while keeping the existing v0 client intact.

Key change: `Orders` acts as a small factory via `__new__`:
- `Orders()` -> legacy v0 client (existing behavior)
- `Orders(version='2026-01-01')` -> returns `OrdersV20260101`

New classes + files:
- `sp_api/api/orders/orders_2026_01_01.py` -> `OrdersV20260101`
- `sp_api/asyncio/api/orders/orders_2026_01_01.py` -> `OrdersV20260101`

New methods in 2026-01-01:
- `search_orders` (GET /orders/2026-01-01/orders)
- `get_order` (GET /orders/2026-01-01/orders/{orderId})

Type hints/overloads added so editors can infer the returned client type.

Model source: https://github.com/amzn/selling-partner-api-models/blob/main/models/orders-api-model/orders_2026-01-01.json
