### PR TITLE
Use single proxy value for httpx

### DIFF
--- a/sp_api/api/data_kiosk/data_kiosk.py
+++ b/sp_api/api/data_kiosk/data_kiosk.py
@@ -1,9 +1,11 @@
-import httpx
 import urllib.parse
 from io import BytesIO, StringIO
 from typing import Union, BinaryIO, TextIO
 
+import httpx
+
 from sp_api.base import Client, sp_endpoint, fill_query_params, ApiResponse
+from sp_api.base._transport_httpx import _httpx_client_kwargs
 
 
 class DataKiosk(Client):
@@ -197,8 +199,10 @@ class DataKiosk(Client):
         )
         if download or file or ("decrypt" in kwargs and kwargs["decrypt"]):
             with httpx.Client(
-                proxies=self.proxies,
-                verify=self.verify,
+                **_httpx_client_kwargs(
+                    proxies=self.proxies,
+                    verify=self.verify,
+                )
             ) as client:
                 document_response = client.get(res.payload.get("documentUrl"))
                 document = document_response.content

--- a/sp_api/api/reports/reports.py
+++ b/sp_api/api/reports/reports.py
@@ -10,6 +10,7 @@ from sp_api.base import (
     ApiResponse,
     Marketplaces,
 )
+from sp_api.base._transport_httpx import _httpx_client_kwargs
 from sp_api.util import (
     normalize_csv_param,
     normalize_datetime_kwargs,
@@ -367,9 +368,11 @@ class Reports(Client):
         if download or file or ("decrypt" in kwargs and kwargs["decrypt"]):
             compression_algorithm = res.payload.get("compressionAlgorithm")
             with httpx.Client(
-                proxies=self.proxies,
-                verify=self.verify,
-                timeout=timeout,
+                **_httpx_client_kwargs(
+                    proxies=self.proxies,
+                    verify=self.verify,
+                    timeout=timeout,
+                )
             ) as client:
                 if stream and file:
                     with client.stream("GET", res.payload.get("url")) as document_response:

--- a/sp_api/base/_transport_httpx.py
+++ b/sp_api/base/_transport_httpx.py
@@ -1,4 +1,19 @@
+import random
+
 import httpx
+
+
+def _httpx_client_kwargs(*, proxies=None, verify=True, timeout=None):
+    client_kwargs = {"verify": verify}
+    if timeout is not None:
+        client_kwargs["timeout"] = timeout
+    if proxies is not None:
+        if isinstance(proxies, (list, tuple)):
+            proxy_value = random.choice(proxies)
+        else:
+            proxy_value = proxies
+        client_kwargs["proxy"] = proxy_value
+    return client_kwargs
 
 
 class HttpxTransport:
@@ -7,9 +22,11 @@ class HttpxTransport:
     ):
         proxy_config = proxy if proxy is not None else proxies
         self._client = client or httpx.Client(
-            timeout=timeout,
-            proxy=proxy_config,
-            verify=verify,
+            **_httpx_client_kwargs(
+                timeout=timeout,
+                proxies=proxy_config,
+                verify=verify,
+            )
         )
 
     def request(self, method, url, *, params=None, data=None, content=None, headers=None):

--- a/tests/api/test_httpx_transport.py
+++ b/tests/api/test_httpx_transport.py
@@ -1,0 +1,24 @@
+import random
+
+from sp_api.base._transport_httpx import _httpx_client_kwargs
+
+
+def test_httpx_client_kwargs_uses_single_proxy_string():
+    proxies = "https://proxy.example"
+
+    kwargs = _httpx_client_kwargs(proxies=proxies, verify=True, timeout=5)
+
+    assert kwargs["proxy"] == "https://proxy.example"
+    assert kwargs["verify"] is True
+    assert kwargs["timeout"] == 5
+
+
+def test_httpx_client_kwargs_selects_proxy_from_list(monkeypatch):
+    proxies = ["https://proxy.example", "https://other.example"]
+
+    monkeypatch.setattr(random, "choice", lambda values: values[0])
+
+    kwargs = _httpx_client_kwargs(proxies=proxies, verify=False)
+
+    assert kwargs["proxy"] == "https://proxy.example"
+    assert kwargs["verify"] is False


### PR DESCRIPTION
### Motivation
- Simplify proxy handling for `httpx.Client` by always passing a single proxy string because `httpx` expects a `proxy` string rather than a mapping. 
- Replace previous mapping-selection logic with behavior matching actual usage: choose one proxy from a list/tuple or use the provided string.

### Description
- Add `_httpx_client_kwargs(*, proxies=None, verify=True, timeout=None)` in `sp_api/base/_transport_httpx.py` that returns a `dict` with a single `proxy` string, selecting one at random if `proxies` is a `list` or `tuple` and otherwise using the provided value. 
- Remove the mapping preference/inspection logic and ensure `HttpxTransport` constructs its client via `**_httpx_client_kwargs(...)` so `proxy` is always a single string. 
- Update synchronous download usages in `sp_api/api/reports/reports.py` and `sp_api/api/data_kiosk/data_kiosk.py` to use `**_httpx_client_kwargs(...)` instead of passing `proxies` directly. 
- Add tests in `tests/api/test_httpx_transport.py` covering a single proxy string and selection from a list via `random.choice` (monkeypatched in the test).

### Testing
- Ran `pytest tests/api/test_httpx_transport.py` and the suite passed with `2 passed` tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69843900566c8328be0d15cabcea5e54)

## Summary by Sourcery

Unify httpx client proxy handling around a single proxy value and apply it consistently across HTTP transport and synchronous document downloads.

Enhancements:
- Introduce a helper to build httpx.Client keyword arguments that always resolve to a single proxy value, randomly selecting from a list or tuple when multiple proxies are provided.
- Update HttpxTransport and synchronous report/data kiosk download code paths to construct httpx.Client instances via the shared helper for consistent proxy, timeout, and verify configuration.

Tests:
- Add unit tests verifying that the httpx client kwargs helper preserves a single proxy string and correctly selects a proxy from a list using random.choice.