### PR TITLE
fix asyncio import error

### DIFF
--- a/sp_api/base/__init__.py
+++ b/sp_api/base/__init__.py
@@ -1,5 +1,6 @@
+from typing import TYPE_CHECKING
+
 from .base_client import BaseClient
-from .client import Client
 from .helpers import (
     fill_query_params,
     sp_endpoint,
@@ -36,10 +37,13 @@ from .ApiResponse import ApiResponse
 from .processing_status import ProcessingStatus
 from .reportTypes import ReportType
 from .feedTypes import FeedType
-from sp_api.auth import AccessTokenClient, Credentials
-from sp_api.auth.exceptions import AuthorizationError
 from sp_api.base.inegibility_reasons import IneligibilityReasonList
 from .marketplaces import AwsEnv
+
+if TYPE_CHECKING:
+    from .client import Client
+    from sp_api.auth import AccessTokenClient, Credentials
+    from sp_api.auth.exceptions import AuthorizationError
 
 
 __all__ = [
@@ -92,3 +96,23 @@ __all__ = [
 # Backward-compatibility aliases for docs and legacy imports.
 FeedTypes = FeedType
 FulfillmentChannels = FulfillmentChannel
+
+
+def __getattr__(name):
+    if name == "Client":
+        from .client import Client
+
+        globals()[name] = Client
+        return Client
+    if name in {"AccessTokenClient", "Credentials"}:
+        from sp_api.auth import AccessTokenClient, Credentials
+
+        exports = {"AccessTokenClient": AccessTokenClient, "Credentials": Credentials}
+        globals()[name] = exports[name]
+        return exports[name]
+    if name == "AuthorizationError":
+        from sp_api.auth.exceptions import AuthorizationError
+
+        globals()[name] = AuthorizationError
+        return AuthorizationError
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")


### PR DESCRIPTION
## Summary by Sourcery

Fix module-level imports in sp_api.base to avoid asyncio-related import errors by lazily loading selected symbols at attribute access time.

Bug Fixes:
- Prevent asyncio import errors by deferring imports of Client, AccessTokenClient, Credentials, and AuthorizationError in sp_api.base until they are first accessed.

Enhancements:
- Introduce lazy attribute-based loading for selected exports in sp_api.base via a module-level __getattr__ and TYPE_CHECKING-only imports to preserve type hints without eager imports.