### PR TITLE
Fix ApplicationIntegrations wrapping request body in extra "body" key

### DIFF
--- a/sp_api/api/application_integrations/application_integrations.py
+++ b/sp_api/api/application_integrations/application_integrations.py
@@ -36,12 +36,12 @@ class ApplicationIntegrations(Client):
         
         Args:
             body: CreateNotificationRequest | required The request body for the `createNotification` operation.
-        
+
         Returns:
             ApiResponse
         """
-    
-        return self._request(kwargs.pop('path'), data=kwargs)
+
+        return self._request(kwargs.pop('path'), data=kwargs.pop('body'), params=kwargs)
     
 
     @sp_endpoint('/appIntegrations/2024-04-01/notifications/deletion', method='POST')
@@ -68,12 +68,12 @@ class ApplicationIntegrations(Client):
         
         Args:
             body: DeleteNotificationsRequest | required The request body for the `deleteNotifications` operation.
-        
+
         Returns:
             ApiResponse
         """
-    
-        return self._request(kwargs.pop('path'), data=kwargs)
+
+        return self._request(kwargs.pop('path'), data=kwargs.pop('body'), params=kwargs)
     
 
     @sp_endpoint('/appIntegrations/2024-04-01/notifications/{}/feedback', method='POST')
@@ -101,9 +101,9 @@ class ApplicationIntegrations(Client):
         Args:
             notificationId: object | required A `notificationId` uniquely identifies a notification.
             body: RecordActionFeedbackRequest | required The request body for the `recordActionFeedback` operation.
-        
+
         Returns:
             ApiResponse
         """
-    
-        return self._request(fill_query_params(kwargs.pop('path'), notificationId), data=kwargs)
+
+        return self._request(fill_query_params(kwargs.pop('path'), notificationId), data=kwargs.pop('body'), params=kwargs)

--- a/sp_api/asyncio/api/application_integrations/application_integrations.py
+++ b/sp_api/asyncio/api/application_integrations/application_integrations.py
@@ -37,12 +37,12 @@ class ApplicationIntegrations(AsyncBaseClient):
         
         Args:
             body: CreateNotificationRequest | required The request body for the `createNotification` operation.
-        
+
         Returns:
             ApiResponse
         """
-    
-        return await self._request(kwargs.pop('path'), data=kwargs)
+
+        return await self._request(kwargs.pop('path'), data=kwargs.pop('body'), params=kwargs)
     
 
     @sp_endpoint('/appIntegrations/2024-04-01/notifications/deletion', method='POST')
@@ -69,12 +69,12 @@ class ApplicationIntegrations(AsyncBaseClient):
         
         Args:
             body: DeleteNotificationsRequest | required The request body for the `deleteNotifications` operation.
-        
+
         Returns:
             ApiResponse
         """
-    
-        return await self._request(kwargs.pop('path'), data=kwargs)
+
+        return await self._request(kwargs.pop('path'), data=kwargs.pop('body'), params=kwargs)
     
 
     @sp_endpoint('/appIntegrations/2024-04-01/notifications/{}/feedback', method='POST')
@@ -102,9 +102,9 @@ class ApplicationIntegrations(AsyncBaseClient):
         Args:
             notificationId: object | required A `notificationId` uniquely identifies a notification.
             body: RecordActionFeedbackRequest | required The request body for the `recordActionFeedback` operation.
-        
+
         Returns:
             ApiResponse
         """
-    
-        return await self._request(fill_query_params(kwargs.pop('path'), notificationId), data=kwargs)
+
+        return await self._request(fill_query_params(kwargs.pop('path'), notificationId), data=kwargs.pop('body'), params=kwargs)


### PR DESCRIPTION
## Summary
- Fixes #2018 — `ApplicationIntegrations.create_notification()` (and `delete_notifications`, `record_action_feedback`) sent the JSON payload as `{"body": {...actual fields...}}` instead of the actual fields at the top level, because the generated code did `data=kwargs` without popping the `body` key out first.
- Amazon rejects the wrapped payload with `InvalidInput: Could not match input arguments`, exactly matching the exception in the issue.
- Fixed both the sync (`sp_api/api/application_integrations/application_integrations.py`) and async (`sp_api/asyncio/api/application_integrations/application_integrations.py`) clients to use `data=kwargs.pop('body')`, matching the convention already used by every other client with the same signature shape (e.g. `AplusContent.create_content_document`, `ListingsItems.put_listings_item`).

## Test plan
- [x] Verified against the exact repro payload from #2018 over a real local HTTP server (not mocked at the transport level) — confirmed the pre-fix code sends `{"body": {"templateId": ..., ...}, "marketplaceIds": [...]}` and the post-fix code sends the fields unwrapped at the top level.
- [x] Verified `delete_notifications` and `record_action_feedback` (including its path-param substitution) the same way.
- [x] No other methods in this client were affected; no other files needed changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct ApplicationIntegrations notification endpoints to send the request body at the top level instead of nested under a "body" key.

Bug Fixes:
- Fix sync ApplicationIntegrations notification methods to unwrap the JSON body and pass remaining kwargs as request params.
- Fix async ApplicationIntegrations notification methods to unwrap the JSON body and pass remaining kwargs as request params.